### PR TITLE
Install dependencies from setup.py

### DIFF
--- a/doc/temboard-install-sources.md
+++ b/doc/temboard-install-sources.md
@@ -11,14 +11,6 @@
 
 ## Installation
 
-Install dependencies with `pip`:
-
-```
-sudo pip install tornado
-sudo pip install psycopg2
-sudo pip install sqlalchemy
-```
-
 Proceed with the installation of the UI:
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
             'temboardui.plugins.settings',
             'temboardui.plugins.activity'],
     scripts = ['temboard', 'temboardui/plugins/supervision/metric-aggregator'],
+    install_requires=requires,
     include_package_data=True,
     zip_safe=False,
     url = '',


### PR DESCRIPTION
Hi,

`python setup.py install` or `pip install -e .` can install dependencies with `install_requires`. This make it easier to track dependencies, conflcts, etc. with `pip-tools` and friends.

Regards,