### PR TITLE
Redirect stderr && stdout to log file if one defined

### DIFF
--- a/temboard
+++ b/temboard
@@ -92,7 +92,7 @@ def main():
         exit(1)
     # Run temboard as a background daemon.
     if (options.daemon):
-        daemonize(options.pidfile)
+        daemonize(options.pidfile, config)
     # Dirty way for getting static/ and templates/ absolute paths.
     import temboardui
     base_path = os.path.dirname(temboardui.__file__)

--- a/temboard
+++ b/temboard
@@ -153,7 +153,11 @@ def main():
     plugins_bind_metadata(application.engine, config.temboard['plugins_orm_engine'])
     # Add signal handlers on SIGTERM.
     signal.signal(signal.SIGTERM, httpd_sigterm_handler)
-    application.listen(config.temboard['port'], address = config.temboard['address'], ssl_options = ssl_ctx)
+    try:
+        application.listen(config.temboard['port'], address = config.temboard['address'], ssl_options = ssl_ctx)
+    except socket.error as e:
+        logger.error("FATAL: " + str(e) + '. Quit');
+        sys.exit(3)
 
     # Task Manager
     task_manager = TaskManager()


### PR DESCRIPTION
Hi.

I faced a problem when daemon silently died on start. I could not understand where the error was. 
Then I noticed that stderr of deamonized process  was redirected to /dev/null. 

My patch redirect it to logfile if one defined by configuration.

