### PR TITLE
Remove pid file before starting temboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ temboard-agent/test/test/configuration.py
 # We provide override. Base compose file comes from
 # https://github.com/dalibo/docker/blob/master/temboard/docker-compose.yml
 docker-compose.yml
+temboard.pid

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,5 +16,6 @@ fi
 
 # Run temboard in the background and wait for ever. This allow to kill temboard
 # without killing the container.
-temboard --daemon
+rm -vf temboard.pid
+temboard --daemon --pid-file temboard.pid
 exec ${*-tail -f /dev/null}


### PR DESCRIPTION
When running `docker-compose up` sometimes `temboard` doesn't start correctly complaining about a `/run/temboard.pid` already existing.