### PR TITLE
Use flake8-diff to catch lint error on new code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+sudo: false
+
+install:
+  - virtualenv venv
+  - venv/bin/pip install flake8 flake8-diff
+  - source venv/bin/activate
+
+script:
+  - flake8-diff $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
This introduces a tiny travis config file to make sure that new or modified python code respect the Flake8 guidelines... until we fix the several lint warning we get on the current code.