### PR TITLE
Don't use 'active' on progress bars to save some CPU

### DIFF
--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -249,7 +249,7 @@ function show_modal_kill(agent_address, agent_port, xsession)
 			type: 'POST',
 			beforeSend: function(xhr){
 				xhr.setRequestHeader('X-Session', xsession);
-				$('#ModalInfo').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+				$('#ModalInfo').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			},
 			async: true,
 			contentType: "application/json",

--- a/temboardui/plugins/dashboard/templates/dashboard.html
+++ b/temboardui/plugins/dashboard/templates/dashboard.html
@@ -132,7 +132,7 @@
         </div>
         <!-- /.panel-heading -->
         <div class="panel-body" id="divNotif10">
-          <div class="row text-center"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div>
+          <div class="row text-center"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div>
         </div>
       </div>
     </div>

--- a/temboardui/plugins/settings/static/js/temboard.settings.js
+++ b/temboardui/plugins/settings/static/js/temboard.settings.js
@@ -10,7 +10,7 @@ function modal_api_call(api_host, api_port, api_url, api_method, xsession, modal
 		data: JSON.stringify(json_params),
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>');
 			xhr.setRequestHeader('X-Session', xsession);
 		},
@@ -98,7 +98,7 @@ function row_edit(row, tableid, modalid, agent_address, agent_port, xsession, fo
 			xhr.setRequestHeader('X-Session', xsession);
 			$('#'+modalid+'Label').html('Processing, please wait...');
 			$('#'+modalid+'Info').html('');
-			$('#'+modalid+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modalid+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modalid+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -484,7 +484,7 @@ function save_hba_table(tableid, modalid, agent_address, agent_port, xsession)
 
 			$('#'+modalid+'Label').html('Processing, please wait...');
 			$('#'+modalid+'Info').html('');
-			$('#'+modalid+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modalid+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modalid+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 			$('#'+modalid).modal('show');
 		},
@@ -522,7 +522,7 @@ function delete_hba(modalid, agent_address, agent_port, xsession, version)
 
 			$('#'+modalid+'Label').html('Processing, please wait...');
 			$('#'+modalid+'Info').html('');
-			$('#'+modalid+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modalid+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modalid+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 			$('#'+modalid).modal('show');
 		},

--- a/temboardui/plugins/supervision/static/js/temboard.supervision.js
+++ b/temboardui/plugins/supervision/static/js/temboard.supervision.js
@@ -19,7 +19,7 @@ function new_graph(id, title, api, api_url, options, start_date, end_date)
 	html_chart_panel += '		</div>';
 	html_chart_panel += '	</div>';
 	html_chart_panel += '	<div class="panel-body">';
-	html_chart_panel += '		<div id="legend'+id+'" class="legend-chart"><div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Loading, please wait ...</div></div></div></div></div>';
+	html_chart_panel += '		<div id="legend'+id+'" class="legend-chart"><div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Loading, please wait ...</div></div></div></div></div>';
 	html_chart_panel += '		<div id="chart'+id+'" class="supervision-chart"></div>';
 	html_chart_panel += '		<div id="visibility'+id+'" class="visibility-chart"></div>';
 	html_chart_panel += '	</div>';

--- a/temboardui/static/js/temboard.manage.group.js
+++ b/temboardui/static/js/temboard.manage.group.js
@@ -10,7 +10,7 @@ function load_update_group_form(modal_id, group_kind, group_name)
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
 			$('#'+modal_id+'Info').html('');
-			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -122,7 +122,7 @@ function send_update_group_form(modal_id, group_kind)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 		},
 		data: data,
 		async: true,
@@ -152,7 +152,7 @@ function load_delete_group_confirm(modal_id, group_kind, group_name)
 		type: 'get',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -197,7 +197,7 @@ function send_delete_group(modal_id, group_kind, group_name)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Body').html('');
 		},
 		async: true,
@@ -266,7 +266,7 @@ function load_add_group_form(modal_id, group_kind)
 			beforeSend: function(xhr){
 				$('#'+modal_id+'Label').html('Processing, please wait...');
 				$('#'+modal_id+'Info').html('');
-				$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+				$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 				$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 			},
 			async: true,
@@ -356,7 +356,7 @@ function send_add_group_form(modal_id, group_kind)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 		},
 		data: data,
 		async: true,

--- a/temboardui/static/js/temboard.manage.instance.js
+++ b/temboardui/static/js/temboard.manage.instance.js
@@ -10,7 +10,7 @@ function load_update_instance_form(modal_id, agent_address, agent_port)
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
 			$('#'+modal_id+'Info').html('');
-			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -143,7 +143,7 @@ function load_update_instance_form(modal_id, agent_address, agent_port)
 					url: '/json/discover/instance/'+$('#inputNewAgentAddress').val()+'/'+$('#inputNewAgentPort').val(),
 					type: 'get',
 					beforeSend: function(xhr){
-						$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+						$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 					},
 					async: true,
 					contentType: "application/json",
@@ -179,7 +179,7 @@ function send_update_instance_form(modal_id, agent_address, agent_port)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 		},
 		data: JSON.stringify({
 			'new_agent_address': $('#inputNewAgentAddress').val(),
@@ -217,7 +217,7 @@ function load_delete_instance_confirm(modal_id, agent_address, agent_port)
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
 			$('#'+modal_id+'Body').html('');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -253,7 +253,7 @@ function send_delete_instance(modal_id, agent_address, agent_port)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Body').html('');
 		},
 		async: true,
@@ -284,7 +284,7 @@ function load_add_instance_form(modal_id)
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
 			$('#'+modal_id+'Info').html('');
-			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -402,7 +402,7 @@ function load_add_instance_form(modal_id)
 					type: 'get',
 					beforeSend: function(xhr){
 						$('#'+modal_id+'Label').html('Processing, please wait...');
-						$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+						$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 					},
 					async: true,
 					contentType: "application/json",
@@ -438,7 +438,7 @@ function send_add_instance_form(modal_id)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 		},
 		data: JSON.stringify({
 			'new_agent_address': $('#inputNewAgentAddress').val(),

--- a/temboardui/static/js/temboard.manage.user.js
+++ b/temboardui/static/js/temboard.manage.user.js
@@ -10,7 +10,7 @@ function load_update_user_form(modal_id, username)
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
 			$('#'+modal_id+'Info').html('');
-			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -122,7 +122,8 @@ function send_update_user_form(modal_id)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
+        debugger;
 		},
 		data: JSON.stringify({
 			'new_username': $('#inputNewUsername').val(),
@@ -155,7 +156,7 @@ function load_delete_user_confirm(modal_id, username)
 		type: 'get',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Body').html('');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
@@ -191,7 +192,7 @@ function send_delete_user(modal_id, username)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Body').html('');
 		},
 		async: true,
@@ -222,7 +223,7 @@ function load_add_user_form(modal_id)
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
 			$('#'+modal_id+'Info').html('');
-			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Body').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 			$('#'+modal_id+'Footer').html('<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>');
 		},
 		async: true,
@@ -316,7 +317,7 @@ function send_add_user_form(modal_id)
 		type: 'post',
 		beforeSend: function(xhr){
 			$('#'+modal_id+'Label').html('Processing, please wait...');
-			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped active" style="width: 100%;">Please wait ...</div></div></div></div>');
+			$('#'+modal_id+'Info').html('<div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Please wait ...</div></div></div></div>');
 		},
 		data: JSON.stringify({
 			'new_username': $('#inputNewUsername').val(),


### PR DESCRIPTION
Here's a quick fix for saving some CPU while displaying the progress bar. The idea is to simply deactivate the animation. This is less pretty but doesn't change the behavior of the application too much.
In the future we may be able to find alternatives.
Fixes #59