### PR TITLE
Pop compose overrides file format to version 3

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   temboardui-ui:


### PR DESCRIPTION
Sync with dalibo/docker#3.

See commit description for further details.