### PR TITLE
debian: ship /etc/temboard directory by default.

### DIFF
--- a/debian/temboard.dirs
+++ b/debian/temboard.dirs
@@ -1,0 +1,1 @@
+/etc/temboard


### PR DESCRIPTION
The default configuration directory should be created by the
package.