### PR TITLE
Ignore closed stream from client

### DIFF
--- a/temboardui/autossl.py
+++ b/temboardui/autossl.py
@@ -35,7 +35,11 @@ from tornado.httputil import (
     ResponseStartLine,
 )
 from tornado.http1connection import HTTP1Connection
-from tornado.iostream import IOStream, SSLIOStream
+from tornado.iostream import (
+    IOStream,
+    SSLIOStream,
+    StreamClosedError,
+)
 from tornado.log import (
     app_log,
     gen_log,
@@ -203,6 +207,9 @@ class AutoHTTPSServer(HTTPServer):
                 logger.exception("Failed to process HTTP request:")
             finally:
                 stream.close()
+        except StreamClosedError:
+            logger.debug("Stream closed by client during handshake. Skipping.")
+            return
         else:
             super(AutoHTTPSServer, self).handle_stream(ssl_stream, address)
 

--- a/test/test_autossl.py
+++ b/test/test_autossl.py
@@ -210,6 +210,26 @@ def test_handle_stream_ssl(mocker):
 
 
 @pytest.mark.gen_test
+def test_handle_stream_closed(mocker):
+    mocker.patch(
+        'temboardui.autossl.AutoHTTPSServer.handle_http_connection'
+    )
+    IOStream = mocker.patch('temboardui.autossl.IOStream')
+
+    from temboardui.autossl import AutoHTTPSServer, StreamClosedError
+
+    server = AutoHTTPSServer(request_callback=Mock('request_callback'))
+
+    ssl_stream = Mock(name='ssl_stream')
+    ssl_stream.wait_for_handshake.side_effect = StreamClosedError()
+
+    yield server.handle_stream(ssl_stream, '127.0.0.1')
+
+    assert ssl_stream.wait_for_handshake.called is True
+    assert IOStream.called is False
+
+
+@pytest.mark.gen_test
 def test_handle_stream_http_request(mocker):
     parent_handle_stream = mocker.patch(
         'temboardui.autossl.HTTPServer.handle_stream'


### PR DESCRIPTION
It's just cosmetic.

An easy way to trigger this case is `nc -q 0 0.0.0.0 8888 < /dev/zero` or simply
use `wait-for-it` from our docker containers.

Fixes:

    SSL Error on 10 ('127.0.0.1', 48334): [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:661)
    Exception in callback <functools.partial object at 0x7f5b1e748418>
    Traceback (most recent call last):
      File "/home/bersace/.local/share/virtualenvs/temboard/local/lib/python2.7/site-packages/tornado/ioloop.py", line 604, in _run_callback
        ret = callback()
      File "/home/bersace/.local/share/virtualenvs/temboard/local/lib/python2.7/site-packages/tornado/stack_context.py", line 275, in null_wrapper
        return fn(*args, **kwargs)
      File "/home/bersace/src/dalibo/temboard-dev/temboardui/autossl.py", line 189, in <lambda>
        self.io_loop.add_future(future, lambda f: f.result())
      File "/home/bersace/.local/share/virtualenvs/temboard/local/lib/python2.7/site-packages/tornado/concurrent.py", line 237, in result
        raise_exc_info(self._exc_info)
      File "/home/bersace/.local/share/virtualenvs/temboard/local/lib/python2.7/site-packages/tornado/gen.py", line 1021, in run
        yielded = self.gen.throw(*exc_info)
      File "/home/bersace/src/dalibo/temboard-dev/temboardui/autossl.py", line 196, in handle_stream
        yield ssl_stream.wait_for_handshake()
      File "/home/bersace/.local/share/virtualenvs/temboard/local/lib/python2.7/site-packages/tornado/gen.py", line 1015, in run
        value = future.result()
      File "/home/bersace/.local/share/virtualenvs/temboard/local/lib/python2.7/site-packages/tornado/concurrent.py", line 237, in result
        raise_exc_info(self._exc_info)
      File "<string>", line 3, in raise_exc_info
    StreamClosedError: Stream is closed