### PR TITLE
Prevent ambiguous arg error in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - pip install --upgrade --requirement requirements-ci.txt
 
 script:
-  - git diff --check $TRAVIS_COMMIT_RANGE
+  - git diff --check $TRAVIS_COMMIT_RANGE --
   - flake8-diff $TRAVIS_COMMIT_RANGE
   - py.test -vv --showlocals --strict --full-trace test/


### PR DESCRIPTION
As suggested by git:

```
fatal: ambiguous argument 'a9231db8b404...a69347a41ab0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```