### PR TITLE
Update url with date range

### DIFF
--- a/temboardui/plugins/monitoring/static/js/temboard.monitoring.js
+++ b/temboardui/plugins/monitoring/static/js/temboard.monitoring.js
@@ -123,13 +123,35 @@ function add_visibility_cb(chart_id, g, is_initial)
 function updateDateRange(start, end) {
   $('#daterange span').html(
     start.format(dateFormat) + ' - ' + end.format(dateFormat));
+  window.location.hash = 'start=' + start + '&end=' + end;
 }
 
-function synchronize_zoom(start_date, end_date, api_url)
+function getHashParams() {
+
+  var hashParams = {};
+  var e;
+  var a = /\+/g;  // Regex for replacing addition symbol with a space
+  var r = /([^&;=]+)=?([^&;]*)/g;
+  var d = function (s) {
+    return decodeURIComponent(s.replace(a, " "));
+  };
+  var q = window.location.hash.substring(1);
+
+  while (e = r.exec(q)) {
+    hashParams[d(e[1])] = d(e[2]);
+  }
+
+  return hashParams;
+}
+
+function synchronize_zoom(start_date, end_date, api_url, silent)
 {
   var picker = $('#daterange').data('daterangepicker');
-  picker.setStartDate(moment(start_date));
-  picker.setEndDate(moment(end_date));
+  if (!silent) {
+    // update picker
+    picker.setStartDate(moment(start_date));
+    picker.setEndDate(moment(end_date));
+  }
 
   // get new date from picker (may be rounded)
   start_date = picker.startDate;

--- a/temboardui/plugins/monitoring/templates/index.html
+++ b/temboardui/plugins/monitoring/templates/index.html
@@ -65,9 +65,23 @@ interval_api_url = api_url+"/interval";
 var dateFormat = 'DD/MM/YYYY HH:mm';
 
 $(document).ready(function() {
+  /**
+   * Parse location hash to get start and end date
+   * If dates are not provided, falls back to the date range corresponding to
+   * the last 24 hours.
+   */
+  var start;
+  var end;
+  var now = moment();
+  var minus24h = now.clone().subtract(24, 'hours');
+  var p = getHashParams();
+  if (p.start && p.end) {
+    start = moment(parseInt(p.start));
+    end = moment(parseInt(p.end));
+  }
+  start = start && start.isValid() ? start : minus24h;
+  end = end && end.isValid() ? end : now;
 
-  var start = moment().subtract(24, 'hours');
-  var end = moment();
   $("#daterange").daterangepicker({
     startDate: start,
     endDate: end,
@@ -79,11 +93,11 @@ $(document).ready(function() {
       format: dateFormat
     },
     ranges: {
-      'Last Hour': [moment().subtract(1, 'hours'), moment()],
-      'Last 24 Hours': [start, end],
-      'Last 7 Days': [moment().subtract(7, 'days'), moment()],
-      'Last 30 Days': [moment().subtract(30, 'days'), moment()],
-      'Last 12 Months': [moment().subtract(12, 'months'), moment()]
+      'Last Hour': [now.clone().subtract(1, 'hours'), now],
+      'Last 24 Hours': [minus24h, now],
+      'Last 7 Days': [now.clone().subtract(7, 'days'), now],
+      'Last 30 Days': [now.clone().subtract(30, 'days'), now],
+      'Last 12 Months': [now.clone().subtract(12, 'months'), now]
     }
   });
   updateDateRange(start, end);
@@ -91,7 +105,8 @@ $(document).ready(function() {
     synchronize_zoom(
       picker.startDate,
       picker.endDate,
-      data_api_url
+      data_api_url,
+      true
     );
   });
 


### PR DESCRIPTION
Fixes #141.

With this pull request the URL reflects the current chosen date range. This allows users to share what they are currently seeing with a copy/paste of the URL.

There's a disadvantage: if the page is left open, the user has to manually click on the "monitoring" item in the menu to get a new range. Previously it was possible to refresh the page and get the last 24 hours range updated.

Not related to the current pull request, I noticed that the predefined date ranges don't update automatically. This means that the last hour shortcut correspond to the hour before the page was open. The dates of the range doesn't update if the page is left open. Is it a problem? What do you think?