### PR TITLE
Cast Taskmanager address and task_path to str

### DIFF
--- a/temboard
+++ b/temboard
@@ -227,8 +227,9 @@ def main():
         os.unlink(tm_sock_path)
 
     tm = taskmanager.TaskManager(
-            task_path=os.path.join(config.temboard['home'], '.tm.task_list'),
-            address=tm_sock_path
+            task_path=str(os.path.join(config.temboard['home'],
+                                       '.tm.task_list')),
+            address=str(tm_sock_path)
          )
     # copy configuration into context as a dict
     tm.set_context(


### PR DESCRIPTION
Prevents errors with address_type failing to be determined
in multiprocessing.connection::Listener