### PR TITLE
Fill line charts with empty data

### DIFF
--- a/temboardui/plugins/dashboard/static/js/temboard.dashboard.js
+++ b/temboardui/plugins/dashboard/static/js/temboard.dashboard.js
@@ -258,12 +258,25 @@ $(function() {
   );
   updateTotalSessions();
 
+  var missingDataCount = config.history_length - jdata_history.length;
+  if (missingDataCount > 0) {
+    var missing = Array.apply(null, {length: missingDataCount});
+    jdata_history = missing.concat(jdata_history);
+  }
+
   var tpsData = jdata_history.map(function(a, index) {
+    if (a === undefined) {
+      return [null, null];
+    }
     if (index === 0) {
       return [0, 0];
     }
     var curr = a.databases;
-    var prev = jdata_history[index - 1].databases;
+    var prev = jdata_history[index - 1];
+    if (!prev) {
+      return [null, null];
+    }
+    prev = prev.databases;
     var duration = curr.timestamp - prev.timestamp;
     var deltaCommit = computeDelta(curr.total_commit, prev.total_commit, duration);
     var deltaRollback = computeDelta(curr.total_rollback, prev.total_rollback, duration);
@@ -331,6 +344,9 @@ $(function() {
     }
   );
 
+  var loadaverageData = jdata_history.map(function(item) {
+    return item ? item.loadaverage : null;
+  });
   var loadaveragechart = new Chart(
     $('#chart-loadaverage').get(0).getContext('2d'),
     {
@@ -340,11 +356,7 @@ $(function() {
         datasets : [
           {
             label: "Loadaverage",
-            data: jdata_history.map(
-              function(item) {
-                return item.loadaverage
-              }
-            ),
+            data: loadaverageData,
             backgroundColor: 'rgba(250, 164, 58, 0.2)',
             borderColor: 'rgba(250, 164, 58, 1)', //'#FAA43A'
           }

--- a/temboardui/plugins/dashboard/static/js/temboard.dashboard.js
+++ b/temboardui/plugins/dashboard/static/js/temboard.dashboard.js
@@ -366,7 +366,8 @@ $(function() {
     }
   );
 
-  window.setInterval(refreshDashboard, 2000);
+  var refreshInterval = config.scheduler_interval * 1000;
+  window.setInterval(refreshDashboard, refreshInterval);
   refreshDashboard();
 });
 

--- a/temboardui/plugins/dashboard/templates/dashboard.html
+++ b/temboardui/plugins/dashboard/templates/dashboard.html
@@ -140,6 +140,7 @@
 <script src="/js/dashboard/temboard.dashboard.js"></script>
 <script src="/js/filesize.min.js"></script>
 <script>
+  var config = JSON.parse('{% raw config %}');
   var jdata_history = JSON.parse('{% raw history %}');
   var lastDatabasesDatum = jdata_history[jdata_history.length -1].databases;
   var xsession = "{{xsession}}";

--- a/temboardui/temboardclient.py
+++ b/temboardui/temboardclient.py
@@ -138,6 +138,23 @@ def temboard_dashboard_history(in_ca_cert_file, hostname, port, xsession):
         raise TemboardError(500, str(e))
 
 
+def temboard_dashboard_config(in_ca_cert_file, hostname, port, xsession):
+    try:
+        res = temboard_request(
+            in_ca_cert_file,
+            method='GET',
+            url='https://%s:%s/dashboard/config' % (hostname, port),
+            headers={
+                "Content-type": "application/json",
+                "X-Session": xsession
+            })
+        return json.loads(res)
+    except urllib2.HTTPError as e:
+        raise TemboardError(e.code, json.loads(e.read())['error'])
+    except Exception as e:
+        raise TemboardError(500, str(e))
+
+
 def temboard_dashboard_live(in_ca_cert_file, hostname, port, xsession):
     try:
         res = temboard_request(


### PR DESCRIPTION
If agent was just started the `loadaverage` and `TPS` charts are currently only showing the data that the history knows about. This may mean only a few points. Then the data is updated each time a new value is received from the dashboard live service. However the number of points in the charts will not increase unless the user refreshes the browser page.
With this PR we get the `history_length` config parameter from the agent (if available) and use it to build the charts and fill it with empty data when appropriate.

![localhost_8888_server_0 0 0 0_2345_dashboard 1280 1](https://user-images.githubusercontent.com/319774/38074227-56e87046-332e-11e8-8d79-9ccd6d59bb61.png)
