### PR TITLE
Alerting stage 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ SETUP_KWARGS = dict(
             'share/sql/application.sql',
             'share/sql/dev-fixture.sql',
             'share/sql/monitoring.sql',
+            'share/sql/alerting.sql',
             'share/sql/upgrade-0.0.1-1.1.sql',
         ]),
         ('share/temboard/quickstart/', [

--- a/share/create_repository.sh
+++ b/share/create_repository.sh
@@ -18,6 +18,7 @@ if ! psql -c "SELECT 'INSTALLED' FROM pg_catalog.pg_class WHERE relname = 'insta
     psql="psql -aw --set ON_ERROR_STOP=on"
     $psql -f $SQLDIR/application.sql
     $psql -f $SQLDIR/monitoring.sql
+    $psql -f $SQLDIR/alerting.sql
     if [ -n "${DEV-}" ] ; then
         $psql -f $SQLDIR/dev-fixture.sql
     fi

--- a/share/sql/alerting.sql
+++ b/share/sql/alerting.sql
@@ -1,0 +1,72 @@
+SET search_path TO monitoring, public;
+
+BEGIN;
+
+CREATE TYPE check_state_type AS ENUM('OK', 'WARNING', 'CRITICAL', 'UNDEF');
+
+CREATE TYPE check_results_record AS (
+	datetime TIMESTAMPTZ,
+	state check_state_type,
+	key VARCHAR(64),
+	value REAL,
+	threshold REAL
+);
+
+CREATE TABLE checks (
+	check_id SERIAL PRIMARY KEY,
+	host_id INTEGER NOT NULL REFERENCES hosts (host_id),
+	instance_id INTEGER REFERENCES instances (instance_id),
+	enabled BOOLEAN NOT NULL DEFAULT false,
+	name VARCHAR(64) NOT NULL,
+	threshold_w REAL,
+	threshold_c REAL,
+	description TEXT
+);
+CREATE INDEX idx_checks_host_instance ON checks (host_id, instance_id);
+
+
+CREATE TABLE check_states (
+	check_id INTEGER NOT NULL REFERENCES checks (check_id),
+	key VARCHAR(64),
+	state check_state_type DEFAULT 'UNDEF',
+	PRIMARY KEY (check_id, key)
+);
+
+CREATE TABLE check_results_current (
+	datetime TIMESTAMPTZ,
+	check_id INTEGER NOT NULL REFERENCES checks (check_id),
+	record check_results_record
+);
+
+CREATE TABLE check_results_history (
+	history_range TSTZRANGE NOT NULL,
+	check_id INTEGER NOT NULL REFERENCES checks (check_id),
+	records check_results_record[]
+);
+
+CREATE OR REPLACE FUNCTION history_check_results() RETURNS BIGINT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	t JSON;
+	v_table_current TEXT;
+	v_table_history TEXT;
+	v_query TEXT;
+	i INTEGER;
+BEGIN
+	LOCK TABLE check_results_current IN SHARE MODE;
+	INSERT INTO check_results_history
+		SELECT
+			tstzrange(min(datetime), max(datetime)),
+			check_id,
+			array_agg(set_datetime_record(datetime, record)::check_results_record) AS records
+		FROM check_results_current
+		GROUP BY date_trunc('day', datetime), 2
+		ORDER BY 1,2 ASC;
+	GET DIAGNOSTICS i = ROW_COUNT;
+	TRUNCATE check_results_current;
+	RETURN i;
+END;
+$$;
+
+COMMIT;

--- a/temboard
+++ b/temboard
@@ -212,6 +212,9 @@ def main():
         cookie_secret=config.temboard['cookie_secret'],
         template_path=base_path + "/templates",
         default_handler_class=Error404Handler)
+
+    config.temboard['tm_sock_path'] = os.path.join(config.temboard['home'],
+                                                   '.tm.socket')
     application.set_config(config)
     application.set_logger(logger)
     config.plugins = application.load_plugins(config.temboard['plugins'])
@@ -220,15 +223,14 @@ def main():
                           config.temboard['plugins_orm_engine'])
 
     # Task Manager
-    tm_sock_path = os.path.join(config.temboard['home'], '.tm.socket')
-    if os.path.exists(tm_sock_path):
+    if os.path.exists(config.temboard['tm_sock_path']):
         # unix socket cleaning
-        os.unlink(tm_sock_path)
+        os.unlink(config.temboard['tm_sock_path'])
 
     tm = taskmanager.TaskManager(
             task_path=str(os.path.join(config.temboard['home'],
                                        '.tm.task_list')),
-            address=str(tm_sock_path)
+            address=str(config.temboard['tm_sock_path'])
          )
     # copy configuration into context as a dict
     tm.set_context(

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -88,6 +88,8 @@ def get_routes(config):
          MonitoringDataProbeHandler, handler_conf),
         (r"/js/monitoring/(.*)", tornado.web.StaticFileHandler,
          {'path': plugin_path + "/static/js"}),
+        (r"/server/(.*)/([0-9]{1,5})/monitoring/json/checks",
+         MonitoringJSONChecksHandler, handler_conf),
     ]
     return routes
 
@@ -986,6 +988,66 @@ class MonitoringHTMLHandler(BaseHandler):
     @tornado.web.asynchronous
     def get(self, agent_address, agent_port):
         run_background(self.get_index, self.async_callback,
+                       (agent_address, agent_port))
+
+
+class MonitoringJSONChecksHandler(JsonHandler):
+
+    def get_checks(self, agent_address, agent_port):
+        try:
+            data = list()
+            instance = None
+            role = None
+
+            self.load_auth_cookie()
+            self.start_db_session()
+
+            role = self.current_user
+            if not role:
+                raise TemboardUIError(302, "Current role unknown.")
+
+            instance = get_instance(self.db_session, agent_address, agent_port)
+            if not instance:
+                raise TemboardUIError(404, "Instance not found.")
+            if __name__ not in [plugin.plugin_name for plugin
+                                in instance.plugins]:
+                raise TemboardUIError(408, "Plugin not active.")
+
+            # Find host_id & instance_id
+            host_id = get_host_id(self.db_session, instance.hostname)
+            instance_id = get_instance_id(self.db_session, host_id,
+                                          instance.pg_port)
+            query = self.db_session.query(
+                        Check.name, CheckState.key, CheckState.state
+                    ).filter(
+                        Check.host_id == host_id,
+                        Check.instance_id == instance_id,
+                        Check.check_id == CheckState.check_id
+                    ).order_by(
+                        Check.name,
+                        CheckState.key
+                    )
+            data = [{'name': r.name, 'key': r.key, 'state': r.state}
+                    for r in query]
+            self.db_session.close()
+            return JSONAsyncResult(http_code=200, data=data)
+
+        except (TemboardUIError, Exception) as e:
+            self.logger.exception(e)
+            try:
+                self.db_session.close()
+            except Exception:
+                pass
+            if (isinstance(e, TemboardUIError)):
+                return JSONAsyncResult(http_code=e.code,
+                                       data={'error': e.message})
+            else:
+                return JSONAsyncResult(http_code=500,
+                                       data={'error': e.message})
+
+    @tornado.web.asynchronous
+    def get(self, agent_address, agent_port):
+        run_background(self.get_checks, self.async_callback,
                        (agent_address, agent_port))
 
 

--- a/temboardui/plugins/monitoring/alerting.py
+++ b/temboardui/plugins/monitoring/alerting.py
@@ -1,0 +1,210 @@
+import operator
+
+
+def bootstrap_checks(hostinfo):
+    # Default checks with thresholds to run against monitoring data
+
+    # Loadaverage (value)
+    # Global to host
+    yield ("loadaverage", hostinfo['n_cpu'] / float(2), hostinfo['n_cpu'])
+    # CPU (percent)
+    # One per CPU
+    yield ("cpu", 50, 80)
+    # Memory usage (percent)
+    # global
+    yield ("memory", 50, 80)
+    # Swap usage (percent)
+    # Global to host
+    yield ("swap", 30, 50)
+    # Filesystems usage (percent)
+    # One per filesystem
+    yield ("fs", 80, 90)
+    # Number of WAL files ready to be archived (value)
+    # Global to postgres instance
+    yield ("archive_ready", 10, 20)
+    # Number of WAL files (value)
+    # Global to postgres instance
+    yield ("wal_files", 50, 100)
+    # Number of transaction rollback (value)
+    # One per DB
+    yield ("xacts_rollback", 10, 20)
+    # Cache hitratio (percent)
+    # One per DB
+    yield ("hitratio", 90, 80)
+    # Client sessions vs max_connections (percent)
+    # Global to postgres instance
+    yield ("sessions", 80, 90)
+    # Waiting sessions (value)
+    # One per DB
+    yield ("waiting", 5, 10)
+
+
+class PreProcess(object):
+
+    @staticmethod
+    def loadaverage(data):
+        return float(data['loadavg'][0]['load1'])
+
+    @staticmethod
+    def cpu(data):
+        _data = dict()
+        for r in data['cpu']:
+            total = 0
+            idle = 0
+            total += int(r['time_system'])
+            total += int(r['time_steal'])
+            total += int(r['time_iowait'])
+            total += int(r['time_user'])
+            total += int(r['time_idle'])
+            idle = int(r['time_idle'])
+            _data[r['cpu']] = int((total - idle) / float(total) * 100)
+        return _data
+
+    @staticmethod
+    def memory(data):
+        return int(
+            (int(data['memory'][0]['mem_total'])
+             - int(data['memory'][0]['mem_free'])
+             - int(data['memory'][0]['mem_cached']))
+            / float(data['memory'][0]['mem_total']) * 100
+        )
+
+    @staticmethod
+    def swap(data):
+        return int(
+            int(data['memory'][0]['swap_used'])
+            / float(data['memory'][0]['swap_total']) * 100
+        )
+
+    @staticmethod
+    def fs(data):
+        _data = dict()
+        for r in data['filesystems_size']:
+            _data[r['mount_point']] = int(int(r['used']) / float(r['total'])
+                                          * 100)
+        return _data
+
+    @staticmethod
+    def archive_ready(data):
+        return int(data['wal_files'][0]['archive_ready'])
+
+    @staticmethod
+    def wal_files(data):
+        return int(data['wal_files'][0]['total'])
+
+    @staticmethod
+    def xacts_rollback(data):
+        _data = dict()
+        for r in data['xacts']:
+            _data[r['dbname']] = int(r['n_rollback'])
+        return _data
+
+    @staticmethod
+    def hitratio(data):
+        _data = dict()
+        for r in data['blocks']:
+            _data[r['dbname']] = int(r['hitmiss_ratio']) \
+                if int(r['blks_read']) + int(r['blks_hit']) > 0 else 100
+        return _data
+
+    @staticmethod
+    def sessions(data):
+        n = 0
+        for r in data['sessions']:
+            n += int(r['idle_in_xact'])
+            n += int(r['idle_in_xact_aborted'])
+            n += int(r['no_priv'])
+            n += int(r['idle'])
+            n += int(r['disabled'])
+            n += int(r['waiting'])
+            n += int(r['active'])
+            n += int(r['fastpath'])
+        return int(n / float(data['max_connections']) * 100)
+
+    @staticmethod
+    def waiting(data):
+        _data = dict()
+        for r in data['sessions']:
+            _data[r['dbname']] = int(r['waiting'])
+        return _data
+
+
+check_specs = dict(
+    loadaverage=dict(
+        type='system',
+        description='Loadaverage',
+        preprocess=PreProcess.loadaverage,
+        message='{value} is greater than {threshold}',
+        operator=operator.gt,
+    ),
+    cpu=dict(
+        type='system',
+        description='CPU usage',
+        preprocess=PreProcess.cpu,
+        message='{value}% is greater than {threshold}%',
+        operator=operator.gt,
+    ),
+    memory=dict(
+        type='system',
+        description='Memory usage',
+        preprocess=PreProcess.memory,
+        message='{value}% is greater than {threshold}%',
+        operator=operator.gt,
+    ),
+    swap=dict(
+        type='system',
+        description='Swap usage',
+        preprocess=PreProcess.swap,
+        message='{value}% is greater than {threshold}%',
+        operator=operator.gt,
+    ),
+    fs=dict(
+        type='system',
+        description='File systems usage',
+        preprocess=PreProcess.fs,
+        message='{key}: {value}% is greater than {threshold}%',
+        operator=operator.gt,
+    ),
+    archive_ready=dict(
+        type='postgres',
+        description='WAL files ready to be archived',
+        preprocess=PreProcess.archive_ready,
+        message='{value} is greater than {threshold}',
+        operator=operator.gt,
+    ),
+    wal_files=dict(
+        type='postgres',
+        description='WAL files',
+        preprocess=PreProcess.wal_files,
+        message='{value} is greater than {threshold}',
+        operator=operator.gt,
+    ),
+    xacts_rollback=dict(
+        type='postgres',
+        description='Rollbacked transactions',
+        preprocess=PreProcess.xacts_rollback,
+        message='{key}: {value} is greater than {threshold}',
+        operator=operator.gt,
+    ),
+    hitratio=dict(
+        type='postgres',
+        description='Cache Hit Ratio',
+        preprocess=PreProcess.hitratio,
+        message='{key}: {value} is less than {threshold}',
+        operator=operator.lt,
+    ),
+    sessions=dict(
+        type='postgres',
+        description='Client sessions',
+        preprocess=PreProcess.sessions,
+        message='{value} is greater than {threshold}',
+        operator=operator.gt,
+    ),
+    waiting=dict(
+        type='postgres',
+        description='Waiting sessions',
+        preprocess=PreProcess.waiting,
+        message='{key}: {value} is greater than {threshold}',
+        operator=operator.gt,
+    ),
+)

--- a/temboardui/plugins/monitoring/model/orm.py
+++ b/temboardui/plugins/monitoring/model/orm.py
@@ -62,3 +62,14 @@ class Instance(Model):
 
     def __repr__(self):
         return "instance: %s:%s" % (self.host_id, self.port)
+
+
+class Check(Model):
+    __table__ = tables.checks
+    host = relationship('Host', backref='checks')
+    instance = relationship('Instance', backref='checks')
+
+
+class CheckState(Model):
+    __table__ = tables.checkstates
+    check = relationship('Check', backref='states')

--- a/temboardui/plugins/monitoring/model/tables.py
+++ b/temboardui/plugins/monitoring/model/tables.py
@@ -16,6 +16,7 @@ from sqlalchemy.types import (
     UnicodeText,
     BigInteger,
     Boolean,
+    REAL,
 )
 
 metadata = MetaData()
@@ -49,4 +50,31 @@ instances = Table(
     Column('sysuser', UnicodeText,),
     Column('standby', Boolean, nullable=False, server_default=text('False')),
     UniqueConstraint('host_id', 'port'),
+    schema="monitoring")
+
+checks = Table(
+    'checks', metadata,
+    Column('check_id', Integer, primary_key=True),
+    Column('host_id', Integer,
+           ForeignKey("monitoring.hosts.host_id"),
+           nullable=False,
+           ),
+    Column('instance_id', Integer,
+           ForeignKey("monitoring.instances.instance_id"),
+           nullable=True,
+           ),
+    Column('enabled', Boolean, nullable=False),
+    Column('name', UnicodeText, nullable=False),
+    Column('threshold_w', REAL),
+    Column('threshold_c', REAL),
+    Column('description', UnicodeText),
+    schema="monitoring")
+
+checkstates = Table(
+    'check_states', metadata,
+    Column('check_id', Integer,
+           ForeignKey("monitoring.checks.check_id"),
+           nullable=False, primary_key=True),
+    Column('key', UnicodeText, nullable=True, primary_key=True),
+    Column('state', UnicodeText, nullable=False),
     schema="monitoring")


### PR DESCRIPTION
This PR introduces alerting (checks) based on monitoring data and working out-of-the-box.

Current checks status can be retrieved with JSON API:
`GET /server/<agent>/<port>/monitoring/json/checks`

Here is an output for example:
```json
[{"state": "OK", "name": "archive_ready", "key": ""},
 {"state": "OK", "name": "cpu", "key": "cpu0"},
 {"state": "OK", "name": "fs", "key": "/"}, 
 {"state": "OK", "name": "fs", "key": "/boot"},
 {"state": "OK", "name": "fs", "key": "/dev"},
 {"state": "OK", "name": "fs", "key": "/dev/shm"},
 {"state": "OK", "name": "fs", "key": "/run"},
 {"state": "OK", "name": "fs", "key": "/run/user/1000"},
 {"state": "OK", "name": "fs", "key": "/sys/fs/cgroup"},
 {"state": "OK", "name": "hitratio", "key": "bench"},
 {"state": "OK", "name": "hitratio", "key": "postgres"},
 {"state": "OK", "name": "hitratio", "key": "temboard"},
 {"state": "OK", "name": "hitratio", "key": "template1"},
 {"state": "CRITICAL", "name": "loadaverage", "key": ""},
 {"state": "OK", "name": "memory", "key": ""},
 {"state": "WARNING", "name": "sessions", "key": ""},
 {"state": "OK", "name": "swap", "key": ""},
 {"state": "CRITICAL", "name": "waiting", "key": "bench"},
 {"state": "OK", "name": "waiting", "key": "postgres"},
 {"state": "OK", "name": "waiting", "key": "temboard"},
 {"state": "OK", "name": "waiting", "key": "template1"},
 {"state": "WARNING", "name": "wal_files", "key": ""},
 {"state": "OK", "name": "xacts_rollback", "key": "bench"},
 {"state": "OK", "name": "xacts_rollback", "key": "postgres"},
 {"state": "OK", "name": "xacts_rollback", "key": "temboard"},
 {"state": "OK", "name": "xacts_rollback", "key": "template1"}]
```