### PR TITLE
Address should be a string not unicode

### DIFF
--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -737,7 +737,7 @@ class MonitoringCollectorHandler(JsonHandler):
             taskmanager.schedule_task(
                 'check_data_worker',
                 options=task_options,
-                listener_addr=config.temboard['tm_sock_path'],
+                listener_addr=str(config.temboard['tm_sock_path']),
             )
 
             return JSONAsyncResult(http_code=200, data={'done': True})


### PR DESCRIPTION
This fixes the following error:
```
ERROR: address type of u'./.tm.socket' unrecognized
ERROR: Traceback (most recent call last):
ERROR:   File "/home/pierre/work/temboard/temboardui/plugins/monitoring/__init__.py", line 740, in push_data
ERROR:     listener_addr=config.temboard['tm_sock_path'],
ERROR:   File "/home/pierre/work/temboard/temboardui/scheduler/taskmanager.py", line 117, in schedule_task
ERROR:     authkey=authkey
ERROR:   File "/home/pierre/work/temboard/temboardui/scheduler/taskmanager.py", line 330, in send_message
ERROR:     conn = Client(address, authkey=authkey)
ERROR:   File "/usr/lib/python2.7/multiprocessing/connection.py", line 165, in Client
ERROR:     family = family or address_type(address)
ERROR:   File "/usr/lib/python2.7/multiprocessing/connection.py", line 111, in address_type
ERROR:     raise ValueError('address type of %r unrecognized' % address)
ERROR: ValueError: address type of u'./.tm.socket' unrecognized
```