### PR TITLE
Use title for state cell if truncated

### DIFF
--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -62,11 +62,12 @@ $(function() {
     ]);
   }
 
+  var stateMaxLength = 12;
   columns = columns.concat([
     {
       title: 'State',
       data: function(row, type, val, meta) {
-        return row.state && row.state.trunc(12);
+        return row.state && row.state.trunc(stateMaxLength);
       },
       className: 'text-center',
       createdCell: function(td, cellData, rowData, row, col) {
@@ -81,6 +82,9 @@ $(function() {
             break;
         }
         $(td).addClass(cls);
+        if (rowData.state.length > stateMaxLength) {
+          $(td).attr('title', rowData.state);
+        }
       }
     },
     {


### PR DESCRIPTION
Because text is truncated, user cannot tell if the state is "idle in transaction" or "idle in transaction (aborted)". With this PR, it's possible to know by hovering the cell.