### PR TITLE
Address should be a string not unicode

### DIFF
--- a/temboardui/plugins/monitoring/handlers/monitoring.py
+++ b/temboardui/plugins/monitoring/handlers/monitoring.py
@@ -160,7 +160,7 @@ class MonitoringCollectorHandler(JsonHandler):
             taskmanager.schedule_task(
                 'check_data_worker',
                 options=task_options,
-                listener_addr=config.temboard['tm_sock_path'],
+                listener_addr=str(config.temboard['tm_sock_path']),
             )
 
             return JSONAsyncResult(http_code=200, data={'done': True})


### PR DESCRIPTION
Monitoring plugin has been refactored recently. The changes applied with https://github.com/dalibo/temboard/commit/916c17626b08880896474ff648ad10964b516b3b have unfortunately been lost.