### PR TITLE
Always show 1h in sparkline even if data is missing

### DIFF
--- a/temboardui/static/js/home.js
+++ b/temboardui/static/js/home.js
@@ -46,8 +46,8 @@ $(function() {
   function createChart() {
     var api_url = ['/server', this.instance.agent_address, this.instance.agent_port, 'monitoring'].join('/');
 
-    var start = moment().subtract(1, 'hours').toISOString();
-    var end = moment().toISOString();
+    var start = moment().subtract(1, 'hours');
+    var end = moment();
     var defaultOptions = {
       axes: {
         x: {
@@ -72,6 +72,7 @@ $(function() {
           }
         }
       },
+      dateWindow: [start, end],
       legend: 'never',
       xValueParser: function(x) {
         var m = moment(x);
@@ -92,7 +93,7 @@ $(function() {
     }
     new Dygraph(
       this.$el,
-      api_url + "/data/" + this.metric + "?start=" + start + "&end=" + end,
+      api_url + "/data/" + this.metric + "?start=" + start.toISOString() + "&end=" + end.toISOString(),
       options
     );
 


### PR DESCRIPTION
Fixes #385 
![capture du 2018-07-06 10-13-10](https://user-images.githubusercontent.com/319774/42367666-3bf3395e-8105-11e8-9e63-d32f21ccc333.png)
