### PR TITLE
Fix readthedoc build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,8 @@ site_author: www.dalibo.com
 copyright: Copyright 2015-2017 <a href="http://www.dalibo.com">dalibo</a>
 repo_url: https://github.com/dalibo/temboard/tree/master/doc
 docs_dir: doc
-theme: readthedocs
+theme:
+- name: readthedocs
 pages:
 - Home: index.md
 - Quick Start: QUICKSTART.md


### PR DESCRIPTION
Currently the readthedoc's build is broken.

```
WARNING -  Config value: 'theme_dir'. Warning: The configuration option {0} has been deprecated and will be removed in a future release of MkDocs.
Aborted with 1 Configuration Warnings in 'strict' mode!
```

See https://www.mkdocs.org/about/release-notes/#theme-customization-1164