### PR TITLE
Display postgres unavailability

### DIFF
--- a/share/sql/monitoring.sql
+++ b/share/sql/monitoring.sql
@@ -1292,6 +1292,24 @@ END;
 
 $$;
 
+CREATE OR REPLACE FUNCTION monitoring.insert_instance_availability(i_tstz TIMESTAMP WITH TIME ZONE, instance_id INTEGER, i_available BOOLEAN)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  s_available BOOLEAN;
+BEGIN
+  SELECT available::BOOLEAN FROM monitoring.instance_availability ORDER BY datetime desc LIMIT 1 INTO s_available;
+  IF s_available IS NULL OR i_available <> s_available THEN
+    INSERT INTO monitoring.instance_availability (datetime, instance_id, available)
+    VALUES (i_tstz, instance_id, i_available);
+  END IF;
+END;
+$$;
+
+CREATE TABLE monitoring.instance_availability(datetime TIMESTAMP WITH TIME ZONE NOT NULL, instance_id INTEGER NOT NULL, available BOOLEAN NOT NULL);
+CREATE INDEX idx_instance_availability ON monitoring.instance_availability (instance_id, datetime);
+
 -- Create the tables if they don't exist
 SELECT * FROM create_tables();
 

--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -161,9 +161,11 @@ $(function() {
       async: true,
       contentType: "application/json",
       success: function (data) {
+        $('#ErrorModal').modal('hide');
         updateActivity(data.rows);
       },
       error: function(xhr) {
+        $('#ErrorModal').modal('hide');
         if (xhr.status == 401) {
           $('#modalError').html(html_error_modal(401, 'Session expired'));
           $('#ErrorModalFooter').html('<a class="btn btn-outline-secondary" id="aBackLogin">Back to login page</a>');
@@ -182,7 +184,6 @@ $(function() {
         }
       },
       complete: function() {
-        $('#ErrorModal').modal('hide');
         $('#loadingIndicator').addClass('d-none');
       }
     });

--- a/temboardui/plugins/dashboard/__init__.py
+++ b/temboardui/plugins/dashboard/__init__.py
@@ -99,8 +99,6 @@ class DashboardHandler(BaseHandler):
                 'dashboard': last_data,
                 'config': json.dumps(config),
                 'history': history,
-                'buffers_delta': 0,
-                'readratio': (100 - last_data['hitratio']),
                 'xsession': xsession,
                 'agent_username': agent_username,
             })

--- a/temboardui/plugins/dashboard/templates/dashboard.html
+++ b/temboardui/plugins/dashboard/templates/dashboard.html
@@ -57,12 +57,24 @@
         </div>
         <div class="small text-center">
           <b id="nb_db">
+            {% if 'databases' in dashboard.keys() %}
             {{ dashboard['databases']['databases'] }}
+            {% end %}
           </b>
           Databases
-          - <b id="size">{{ dashboard['databases']['total_size'] }}</b>
+          -
+          <b id="size">
+            {% if 'databases' in dashboard.keys() %}
+            {{ dashboard['databases']['total_size'] }}
+            {% end %}
+          </b>
           <br>
-          Uptime: <strong id="pg_uptime">{{ dashboard['pg_uptime'] }}</strong>
+          Uptime:
+          <strong id="pg_uptime">
+            {% if 'pg_uptime' in dashboard.keys() %}
+            {{ dashboard['pg_uptime'] }}
+            {% end %}
+          </strong>
         </div>
         <div class="row mt-2">
           <div class="col-6 small text-center">
@@ -83,6 +95,15 @@
             </div>
             <div class="card-body p-2 chart-small">
               <canvas id="chart-sessions"></canvas>
+            </div>
+          </div>
+          <div id="postgres-stopped-msg" style="position: absolute; width: 100%; height: 100%; top: 0; display: flex; align-items: center; justify-content: center; opacity: 0.9;" class="alert alert-warning border border-warning d-none">
+            <div class="text-center">
+              <i class="fa fa-exclamation-triangle fa-2x"></i>
+              <br>
+              PostgreSQL instance
+              <br>
+              is unreachable
             </div>
           </div>
         </div>

--- a/temboardui/plugins/dashboard/templates/dashboard.html
+++ b/temboardui/plugins/dashboard/templates/dashboard.html
@@ -214,11 +214,11 @@
 </div>
 
 <!-- <script src="/js/Chart.js"></script> -->
+<script src="/js/moment.min.js"></script>
 <script src="/js/vue.min.js"></script>
 <script src="/js/Chart.min.js"></script>
 <script src="/js/dashboard/temboard.dashboard.js"></script>
 <script src="/js/filesize.min.js"></script>
-<script src="/js/moment.min.js"></script>
 <script>
   var config = JSON.parse('{% raw config %}');
   var jdata_history = JSON.parse('{% raw history %}');

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -27,9 +27,10 @@ from .handlers.alerting import (
     AlertingJSONCheckChangesHandler,
 )
 from .handlers.monitoring import (
-    MonitoringHTMLHandler,
+    MonitoringAvailabilityHandler,
     MonitoringCollectorHandler,
     MonitoringDataMetricHandler,
+    MonitoringHTMLHandler,
     MonitoringUnavailabilityHandler,
 )
 
@@ -59,6 +60,8 @@ def get_routes(config):
          MonitoringCollectorHandler, handler_conf),
         (r"/server/(.*)/([0-9]{1,5})/monitoring/data/([a-z\-_.0-9]{1,64})$",
          MonitoringDataMetricHandler, handler_conf),
+        (r"/server/(.*)/([0-9]{1,5})/monitoring/availability",
+         MonitoringAvailabilityHandler, handler_conf),
         (r"/server/(.*)/([0-9]{1,5})/monitoring/unavailability",
          MonitoringUnavailabilityHandler, handler_conf),
         (r"/js/monitoring/(.*)",

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -219,6 +219,15 @@ def check_data_worker(dbconf, host_id, instance_id, data):
                                "check_id = :check_id AND NOT (key = ANY(:ks))",
                                {'check_id': check_id, 'ks': ks})
         worker_session.commit()
+
+    # Set to UNDEF every unchecked check
+    # This may happen when postgres is unavailable for example
+    worker_session.execute("UPDATE monitoring.check_states "
+                           "SET state = 'UNDEF' "
+                           "WHERE NOT check_id = ANY(:check_ids)",
+                           {'check_ids': keys.keys()})
+    worker_session.commit()
+
     worker_session.close()
 
 

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -30,6 +30,7 @@ from .handlers.monitoring import (
     MonitoringHTMLHandler,
     MonitoringCollectorHandler,
     MonitoringDataMetricHandler,
+    MonitoringUnavailabilityHandler,
 )
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,8 @@ def get_routes(config):
          MonitoringCollectorHandler, handler_conf),
         (r"/server/(.*)/([0-9]{1,5})/monitoring/data/([a-z\-_.0-9]{1,64})$",
          MonitoringDataMetricHandler, handler_conf),
+        (r"/server/(.*)/([0-9]{1,5})/monitoring/unavailability",
+         MonitoringUnavailabilityHandler, handler_conf),
         (r"/js/monitoring/(.*)",
          tornado.web.StaticFileHandler, {'path': plugin_path + "/static/js"}),
         (r"/server/(.*)/([0-9]{1,5})/alerting/alerts.json",

--- a/temboardui/plugins/monitoring/chartdata.py
+++ b/temboardui/plugins/monitoring/chartdata.py
@@ -811,3 +811,18 @@ def get_unavailability_csv(session, start, end, host_id, instance_id):
     data_buffer.close()
 
     return data
+
+
+def get_availability(session, host_id, instance_id):
+
+    # Tell whether the instance is currently available or not
+    cur = session.connection().connection.cursor()
+    cur.execute("SET search_path TO monitoring")
+    sql = """
+        SELECT available FROM instance_availability
+        WHERE instance_id = :instance_id
+        ORDER BY datetime desc
+        LIMIT 1
+    """
+    result = session.execute(sql, {'instance_id': instance_id}).fetchone()
+    return bool(result[0]) if result else False

--- a/temboardui/plugins/monitoring/static/js/temboard.monitoring.js
+++ b/temboardui/plugins/monitoring/static/js/temboard.monitoring.js
@@ -408,10 +408,12 @@ $(function() {
     for (var attrname in metrics[id].options) {
       defaultOptions[attrname] = metrics[id].options[attrname];
     }
+
+    var url = apiUrl+"/"+metrics[id].api+"?start="+timestampToIsoDate(startDate)+"&end="+timestampToIsoDate(endDate)+"&noerror=1";
     if (!this.graph.chart || create) {
       this.graph.chart = new Dygraph(
         document.getElementById("chart"+id),
-        apiUrl+"/"+metrics[id].api+"?start="+timestampToIsoDate(startDate)+"&end="+timestampToIsoDate(endDate)+"&noerror=1",
+        url,
         defaultOptions
       );
     } else {
@@ -422,7 +424,7 @@ $(function() {
         });
         // load the data for the given range
         this.graph.chart.updateOptions({
-          file: apiUrl+"/"+metrics[id].api+"?start="+timestampToIsoDate(startDate)+"&end="+timestampToIsoDate(endDate)+"&noerror=1"
+          file: url
         }, false);
       }.bind(this));
     }

--- a/temboardui/plugins/monitoring/static/js/temboard.monitoring.js
+++ b/temboardui/plugins/monitoring/static/js/temboard.monitoring.js
@@ -241,7 +241,9 @@ $(function() {
         createOrUpdateChart.call(this, true);
       },
       // only one watcher for from + to
-      fromTo: createOrUpdateChart
+      fromTo: function() {
+        createOrUpdateChart.call(this, false);
+      }
     },
     computed: {
       fromTo: function() {

--- a/temboardui/plugins/monitoring/templates/index.html
+++ b/temboardui/plugins/monitoring/templates/index.html
@@ -121,7 +121,8 @@
 <script src="/js/monitoring/daterangepicker.vue.js"></script>
 <script src="/js/monitoring/temboard.monitoring.js"></script>
 <script>
-var apiUrl = "/server/{{instance.agent_address}}/{{instance.agent_port}}/monitoring/data"
+var apiUrl = "/server/{{instance.agent_address}}/{{instance.agent_port}}/monitoring/data";
+var unavailabilityUrl = "/server/{{instance.agent_address}}/{{instance.agent_port}}/monitoring/unavailability";
 </script>
 
 {% end %}

--- a/temboardui/plugins/monitoring/tools.py
+++ b/temboardui/plugins/monitoring/tools.py
@@ -127,6 +127,38 @@ def check_host_key(session, hostname, agent_key):
     raise Exception("Can't check agent's key.")
 
 
+def insert_availability(session, host, agent_data, logger, hostname, port):
+    try:
+        # Find host_id & instance_id
+        host_id = get_host_id(session, hostname)
+        instance_id = get_instance_id(session, host_id, port)
+    except Exception as e:
+        logger.info("Unable to find host & instance IDs")
+        logger.exception(str(e))
+        session.rollback()
+        return
+
+    cur = session.connection().connection.cursor()
+    cur.execute("SET search_path TO monitoring")
+    try:
+        query = """
+            SELECT insert_instance_availability(%s, %s, %s)
+        """
+        cur.execute(
+            query,
+            (
+                agent_data['datetime'],
+                instance_id,
+                agent_data['instances'][0]['available']
+            )
+        )
+        cur.close()
+    except Exception as e:
+        logger.info("Availability data not inserted")
+        logger.exception(str(e))
+        session.connection().connection.rollback()
+
+
 def insert_metrics(session, host, agent_data, logger, hostname, port):
     try:
         # Find host_id & instance_id

--- a/temboardui/static/js/home.js
+++ b/temboardui/static/js/home.js
@@ -29,9 +29,10 @@ $(function() {
     template: `
     <div>
     Status:
-    <span class="badge badge-ok" v-if="!checks.WARNING && !checks.CRITICAL">OK</span>
+    <span class="badge badge-ok" v-if="!checks.WARNING && !checks.CRITICAL && !checks.UNDEF">OK</span>
     <span class="badge badge-warning" v-if="checks.WARNING">WARNING: {{ checks.WARNING }}</span>
     <span class="badge badge-critical" v-if="checks.CRITICAL">CRITICAL: {{ checks.CRITICAL }}</span>
+    <span class="badge badge-undef" v-if="checks.UNDEF">UNDEF: {{ checks.UNDEF }}</span>
     </div>
     `
   });
@@ -103,10 +104,13 @@ $(function() {
     var checks = instance.checks;
     var value = 0;
     if (checks.CRITICAL) {
-      value += checks.CRITICAL * 1000;
+      value += checks.CRITICAL * 1000000;
     }
     if (checks.WARNING) {
-      value += checks.WARNING;
+      value += checks.WARNING* 1000;
+    }
+    if (checks.UNDEF) {
+      value += checks.UNDEF;
     }
     return value;
   }

--- a/temboardui/static/js/home.js
+++ b/temboardui/static/js/home.js
@@ -40,6 +40,10 @@ $(function() {
   var search = getParameterByName('q') || '';
   var sort = getParameterByName('sort') || 'hostname';
 
+  $.each(instances, function(index, instance) {
+    instance.available = null;
+  });
+
   var instancesVue = new Vue({
     el: '#instances',
     data: {
@@ -79,8 +83,10 @@ $(function() {
     }
   });
 
+  checkAvailability();
   window.setInterval(function() {
     instancesVue.update = moment();
+    checkAvailability();
   }, refreshInterval);
 
   function updateQueryParams() {
@@ -222,5 +228,15 @@ $(function() {
     }
 
     return number;
+  }
+
+  function checkAvailability() {
+    instances.forEach(function(instance) {
+      var api_url = ['/server', instance.agent_address, instance.agent_port, 'monitoring'].join('/');
+      $.ajax(api_url + '/availability')
+      .success(function(data) {
+        instance.available = data.available;
+      });
+    });
   }
 });

--- a/temboardui/templates/home.html
+++ b/temboardui/templates/home.html
@@ -53,6 +53,9 @@ var instances = {% raw json.dumps([i for i in instance_list], cls=json_encoder.n
               {{!instance.hostname}}
               </a>
             </strong>
+            <div v-if="instance.available === false">
+              <span class="badge badge-warning"><i class="fa fa-exclamation-triangle"></i> Unable to connect to postgres</span>
+            </div>
             <checks :instance="instance" :update="update"></checks>
           </div>
         </div>


### PR DESCRIPTION
The idea behind this PR is to make sure that we correctly handle the possible unavailability of the postgres instance. The agent may continue to work but being unable to connect to postgres. Until now, it was impossible to tell on the interface. The charts continue to display data as if nothing happened.
The dashboard freezes without any notifications.

Now the availability/unavailability of the postgres instance is stored in the repository and can be used in different places in the UI.

Home page (non continous data in tps chart, message)
![capture du 2018-10-19 16-57-38](https://user-images.githubusercontent.com/319774/47227012-26086280-d3c2-11e8-8717-c7af88634029.png)

Dashboard (unreachable message, incomplete chart, undef status)
![capture du 2018-10-19 16-33-25](https://user-images.githubusercontent.com/319774/47227097-4e905c80-d3c2-11e8-95de-f63f8ff46f97.png)

Relies on a PR for the agent: https://github.com/dalibo/temboard-agent/pull/253

