### PR TITLE
Fail safely if max_connections is not provided

### DIFF
--- a/temboardui/plugins/monitoring/handlers/monitoring.py
+++ b/temboardui/plugins/monitoring/handlers/monitoring.py
@@ -101,8 +101,9 @@ class MonitoringCollectorHandler(JsonHandler):
             thread_session.close()
 
             # Add max_connections value to data
-            data['data']['max_connections'] = \
-                data['instances'][0]['max_connections']
+            if 'max_connections' in data['instances'][0].keys():
+                data['data']['max_connections'] = \
+                    data['instances'][0]['max_connections']
 
             task_options = dict(dbconf=config.repository,
                                 host_id=host_id,


### PR DESCRIPTION
In some cases (instance not available) we don't have max_connections provided. The problem is that the data collector fails and the agent keep the data in the queue. Thus no data can be sent to UI.