### PR TITLE
Drop tornado.web.asynchronous for notifications page

### DIFF
--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -32,9 +32,6 @@ from .handlers.user import (
     LoginJsonHandler,
     LogoutHandler,
 )
-from .handlers.notification import (
-    NotificationsHandler,
-)
 from .handlers.settings.user import (
     SettingsDeleteUserJsonHandler,
     SettingsUserHandler,
@@ -102,6 +99,7 @@ def setup_tornado_app(app, config):
     base_path = os.path.dirname(__file__)
     # Load handlers
     __import__('temboardui.handlers.home')
+    __import__('temboardui.handlers.notification')
 
     handler_conf = {
         'ssl_ca_cert_file': config.temboard['ssl_ca_cert_file'],
@@ -146,9 +144,6 @@ def setup_tornado_app(app, config):
          DiscoverInstanceJsonHandler, handler_conf),
         # Agent Login
         (r"/server/(.*)/([0-9]{1,5})/login", AgentLoginHandler,
-         handler_conf),
-        # Notifications
-        (r"/server/(.*)/([0-9]{1,5})/notifications", NotificationsHandler,
          handler_conf),
         (r"/css/(.*)", tornado.web.StaticFileHandler, {
             'path': base_path + '/static/css'

--- a/temboardui/handlers/notification.py
+++ b/temboardui/handlers/notification.py
@@ -1,56 +1,19 @@
-import tornado.web
-
-from temboardui.errors import TemboardUIError
-from temboardui.temboardclient import (
-    temboard_get_notifications,
-    temboard_profile,
-)
-from temboardui.handlers.base import BaseHandler
-from temboardui.async import (
-    HTMLAsyncResult,
-    run_background,
+from ..web import (
+    app,
+    render_template,
 )
 
 
-class NotificationsHandler(BaseHandler):
-
-    @BaseHandler.catch_errors
-    def get_notifications(self, agent_address, agent_port):
-        self.logger.info("Getting notifications.")
-
-        self.setUp(agent_address, agent_port)
-
-        xsession = self.get_secure_cookie(
-            "temboard_%s_%s" % (agent_address, agent_port))
-        if not xsession:
-            raise TemboardUIError(401, "Authentication cookie is missing.")
-        else:
-            data_profile = temboard_profile(self.ssl_ca_cert_file,
-                                            agent_address,
-                                            agent_port,
-                                            xsession)
-            agent_username = data_profile['username']
-
-        # Load notifications.
-        notifications = temboard_get_notifications(self.ssl_ca_cert_file,
-                                                   agent_address,
-                                                   agent_port,
-                                                   xsession)
-        self.logger.info("Done.")
-        return HTMLAsyncResult(
-                http_code=200,
-                template_file='notifications.html',
-                data={
-                    'nav': True,
-                    'role': self.current_user,
-                    'instance': self.instance,
-                    'plugin': 'notifications',
-                    'notifications': notifications,
-                    'xsession': xsession,
-                    'agent_username': agent_username,
-                })
-
-    @tornado.web.asynchronous
-    def get(self, agent_address, agent_port):
-        run_background(self.get_notifications, self.async_callback,
-                       (agent_address, agent_port))
+@app.instance_route(r"/notifications")
+def notifications(request):
+    agent_profile = request.instance.get_profile()
+    notifications = request.instance.get_notifications()
+    return render_template(
+        'notifications.html',
+        agent_username=agent_profile['username'],
+        instance=request.instance,
+        nav=True,
+        notifications=notifications,
+        plugin='notifications',
+        role=request.current_user,
+    )

--- a/tests/func/run.sh
+++ b/tests/func/run.sh
@@ -24,7 +24,8 @@ teardown() {
 	trap - EXIT INT TERM
 
 	if [ -f $LOGFILE ] ; then
-		cat $LOGFILE >&2
+		# Trim line from syslog-like prefix.
+		sed 's/.*\]: //g' $LOGFILE >&2
 	fi
 
 	# If not on CI and we are docker entrypoint (PID 1), let's wait forever on
@@ -63,7 +64,7 @@ pip2.7 install \
        --requirement tests/func/requirements.txt
 
 rm -f $LOGFILE
-TEMBOARD_LOGGING_METHOD=file TEMBOARD_LOGGING_DESTINATION=$LOGFILE \
+TEMBOARD_LOGGING_METHOD=file TEMBOARD_LOGGING_DESTINATION=${PWD}/$LOGFILE \
 		       temboard --daemon --debug --pid-file ${PIDFILE}
 wait-for-it.sh 0.0.0.0:8888
 

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -21,14 +21,14 @@ def test_app_route(mocker):
 
     app = WebApplication()
 
-    @app.route('/')
+    @app.route('/', methods=['GET', 'POST'])
     def index(request):
         pass
 
     request = mocker.Mock(name='request', host_name='0.0.0.0', path='/')
     handler = app.default_router.find_handler(request)
 
-    assert handler.handler_kwargs['callable_'] is index
+    assert handler.handler_kwargs['methods'] == ['GET', 'POST']
 
 
 def test_handler(executor, io_loop, mocker):


### PR DESCRIPTION
This PR provides:
- middleware to help interacting with an instance (this is the majority of all handlers)
- drop @asynchronous usage on notifications page
- fix 404 on inexistant instance