### PR TITLE
 Drop asynchronous decorator for instance login 

### DIFF
--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -25,9 +25,6 @@ from .web import app
 from .handlers.base import (
     Error404Handler,
 )
-from .handlers.user import (
-    AgentLoginHandler,
-)
 from .handlers.settings.user import (
     SettingsDeleteUserJsonHandler,
     SettingsUserHandler,
@@ -96,6 +93,7 @@ def setup_tornado_app(app, config):
     # Load handlers
     __import__('temboardui.handlers.home')
     __import__('temboardui.handlers.notification')
+    __import__('temboardui.handlers.user')
 
     handler_conf = {
         'ssl_ca_cert_file': config.temboard['ssl_ca_cert_file'],
@@ -134,9 +132,6 @@ def setup_tornado_app(app, config):
         # Discover
         (r"/json/discover/instance/([0-9a-zA-Z\-\._:]+)/([0-9]{1,5})$",
          DiscoverInstanceJsonHandler, handler_conf),
-        # Agent Login
-        (r"/server/(.*)/([0-9]{1,5})/login", AgentLoginHandler,
-         handler_conf),
         (r"/css/(.*)", tornado.web.StaticFileHandler, {
             'path': base_path + '/static/css'
         }),

--- a/temboardui/handlers/user.py
+++ b/temboardui/handlers/user.py
@@ -1,24 +1,14 @@
 import logging
-import tornado.web
 from time import sleep
 
-from temboardui.handlers.base import BaseHandler
-from temboardui.temboardclient import (
-    TemboardError,
-    temboard_login,
-    temboard_profile,
-)
-from temboardui.async import (
-    HTMLAsyncResult,
-    run_background,
-)
-from temboardui.application import (
+import tornado.web
+
+from ..application import (
     gen_cookie,
-    get_instance,
     get_role_by_auth,
     hash_password,
 )
-from temboardui.errors import TemboardUIError
+from ..errors import TemboardUIError
 from ..web import (
     Redirect,
     Response,
@@ -94,118 +84,35 @@ def json_login(request):
         )
 
 
-class AgentLoginHandler(BaseHandler):
-    """ Login Handler """
+@app.instance_route(r'/login', methods=['GET', 'POST'])
+def agent_login(request):
+    error = None
+    username = None
+    if 'GET' == request.method:
+        if not request.current_user:
+            return Redirect('/login')
 
-    def get_login(self, agent_address, agent_port):
+        if request.instance.xsession:
+            profile = request.instance.get_profile()
+            username = profile['username']
+    else:
         try:
-            instance = None
-            role = None
-            agent_username = None
-            self.start_db_session()
-            try:
-                self.load_auth_cookie()
-                role = self.current_user
-            except Exception as e:
-                pass
-            if role is None:
-                raise TemboardUIError(302, "Current role unknown.")
-
-            instance = get_instance(self.db_session, agent_address, agent_port)
-            xsession = self.get_secure_cookie(
-                "temboard_%s_%s" % (instance.agent_address,
-                                    instance.agent_port))
-            if xsession:
-                try:
-                    data_profile = temboard_profile(self.ssl_ca_cert_file,
-                                                    instance.agent_address,
-                                                    instance.agent_port,
-                                                    xsession)
-                    agent_username = data_profile['username']
-                    self.logger.error(agent_username)
-                except Exception as e:
-                    self.logger.exception(str(e))
-
-            return HTMLAsyncResult(
-                http_code=200,
-                template_file='agent-login.html',
-                data={
-                    'nav': True,
-                    'instance': instance,
-                    'role': role,
-                    'username': agent_username
-                })
-        except (TemboardUIError, TemboardError, Exception) as e:
-            self.logger.exception(str(e))
-            if (isinstance(e, TemboardUIError) or
-               isinstance(e, TemboardError)):
-                if e.code == 302:
-                    return HTMLAsyncResult(http_code=401, redirection="/login")
-                code = e.code
-            else:
-                code = 500
-            return HTMLAsyncResult(
-                http_code=code,
-                template_file='error.html',
-                data={
-                    'nav': True,
-                    'instance': instance,
-                    'code': str(e.code),
-                    'message': str(e.message)
-                })
-
-    @tornado.web.asynchronous
-    def get(self, agent_address, agent_port):
-        run_background(self.get_login, self.async_callback,
-                       (agent_address, agent_port))
-
-    def post_login(self, agent_address, agent_port):
-        try:
-            self.logger.info("Posting to agent login.")
-            instance = None
-            self.load_auth_cookie()
-            self.start_db_session()
-
-            role = self.current_user
-            if not role:
-                raise TemboardUIError(302, "Current role unknown.")
-
-            instance = get_instance(self.db_session, agent_address, agent_port)
-
-            xsession = temboard_login(
-                        self.ssl_ca_cert_file,
-                        instance.agent_address,
-                        instance.agent_port,
-                        self.get_argument("username"),
-                        self.get_argument("password"))
-
-            self.set_secure_cookie(
-                "temboard_%s_%s" %
-                (instance.agent_address, instance.agent_port),
-                xsession,
-                expires_days=30
+            xsession = request.instance.login(
+                request.handler.get_argument('username'),
+                request.handler.get_argument('password'),
             )
-            self.logger.info("Done.")
-            redirection = self.get_secure_cookie('referer_uri') \
-                if self.get_secure_cookie('referer_uri') is not None \
-                else "/server/%s/%s/dashboard" % (instance.agent_address,
-                                                  instance.agent_port)
-            return HTMLAsyncResult(http_code=302,
-                                   redirection=redirection)
-        except (TemboardError, TemboardUIError, Exception) as e:
-            self.logger.exception(str(e))
-            self.logger.info("Failed.")
-            return HTMLAsyncResult(
-                    http_code=200,
-                    template_file='agent-login.html',
-                    data={
-                        'nav': True,
-                        'error': e.message,
-                        'instance': instance,
-                        'username': None
-                    })
+        except Exception as e:
+            error = str(e)
+        else:
+            cookies = {request.instance.cookie_name: xsession}
+            location = request.handler.get_secure_cookie('referer_uri')
+            if not location:
+                location = request.instance.format_url('/dashboard')
+            return Redirect(location, secure_cookies=cookies)
 
-    @tornado.web.asynchronous
-    def post(self, agent_address, agent_port):
-        run_background(self.post_login, self.async_callback,
-                       (agent_address, agent_port))
+    return render_template(
+        'agent-login.html',
+        nav=True, instance=request.instance, username=username,
+        role=request.current_user,
+        error=error,
+    )

--- a/temboardui/handlers/user.py
+++ b/temboardui/handlers/user.py
@@ -61,9 +61,7 @@ def login(request):
             password = request.handler.get_argument('password')
             cookies = login_common(request.db_session, rolename, password)
             referer = request.handler.get_secure_cookie('referer_uri')
-            response = Redirect(referer or '/home')
-            response.secure_cookies.update(cookies)
-            return response
+            return Redirect(referer or '/home', secure_cookies=cookies)
         except TemboardUIError as e:
             logger.error(u"Login failed: %s", e)
             response = render_template(

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -44,11 +44,12 @@ class Response(object):
 
 
 class Redirect(Response, Exception):
-    def __init__(self, location, permanent=False):
+    def __init__(self, location, permanent=False, secure_cookies=None):
         super(Redirect, self).__init__(
             status_code=301 if permanent else 302,
             headers={'Location': location},
             body=u'Redirected to %s' % location,
+            secure_cookies=secure_cookies,
         )
 
 

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -305,6 +305,7 @@ class Blueprint(object):
                 func = InstanceHelper.add_middleware(func)
 
             @run_on_executor
+            @functools.wraps(func)
             def wrapper(request, *args):
                 try:
                     return func(request, *args)

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -232,7 +232,7 @@ class InstanceHelper(object):
             body=json.loads(body),
         )
 
-    def get_xsession(self):
+    def require_xsession(self):
         if not self.xsession:
             self.redirect_login()
         return self.xsession
@@ -243,7 +243,7 @@ class InstanceHelper(object):
                 self.request.config.temboard.ssl_ca_cert_file,
                 self.instance.agent_address,
                 self.instance.agent_port,
-                self.get_xsession(),
+                self.require_xsession(),
             )
         except TemboardError as e:
             if 401 == e.code:
@@ -256,7 +256,7 @@ class InstanceHelper(object):
             self.request.config.temboard.ssl_ca_cert_file,
             self.instance.agent_address,
             self.instance.agent_port,
-            self.get_xsession(),
+            self.require_xsession(),
         )
 
 

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -24,8 +24,9 @@ from .application import (
 from .model import Session as DBSession
 from .temboardclient import (
     TemboardError,
-    temboard_profile,
     temboard_get_notifications,
+    temboard_login,
+    temboard_profile,
     temboard_request,
 )
 
@@ -259,6 +260,14 @@ class InstanceHelper(object):
             self.instance.agent_address,
             self.instance.agent_port,
             self.require_xsession(),
+        )
+
+    def login(self, username, password):
+        return temboard_login(
+            self.request.config.temboard.ssl_ca_cert_file,
+            self.instance.agent_address,
+            self.instance.agent_port,
+            username, password,
         )
 
 

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -199,10 +199,11 @@ class InstanceHelper(object):
                 self.cookie_name)
         return self._xsession
 
-    def redirect_login(self):
-        login_url = "/server/%s/%s/login" % (
-            self.instance.agent_address, self.instance.agent_port)
-        raise Redirect(location=login_url)
+    def format_url(self, path=''):
+        return "/server/%s/%s%s" % (self.agent_address, self.agent_port, path)
+
+    def redirect(self, path):
+        raise Redirect(location=self.format_url(path))
 
     def proxy(self, method, path, body=None):
         url = 'https://%s:%s%s' % (
@@ -235,7 +236,7 @@ class InstanceHelper(object):
 
     def require_xsession(self):
         if not self.xsession:
-            self.redirect_login()
+            self.redirect('/login')
         return self.xsession
 
     def get_profile(self):
@@ -248,7 +249,7 @@ class InstanceHelper(object):
             )
         except TemboardError as e:
             if 401 == e.code:
-                self.redirect_login()
+                self.redirect('/login')
             logger.error('Instance error: %s', e)
             raise HTTPError(500)
 


### PR DESCRIPTION
Tested:

- [x] Bad username, bad password
- [x] Successful login
- [x] GET logged