### PR TITLE
Drop asynchronous decorator from /json/settings/group/…

### DIFF
--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -32,7 +32,6 @@ from .handlers.settings.user import (
 )
 from .handlers.settings.group import (
     SettingsDeleteGroupJsonHandler,
-    SettingsGroupAllJsonHandler,
     SettingsGroupHandler,
     SettingsGroupJsonHandler,
 )
@@ -108,8 +107,6 @@ def setup_tornado_app(app, config):
          SettingsUserJsonHandler, handler_conf),
         (r"/json/settings/delete/user$", SettingsDeleteUserJsonHandler,
          handler_conf),
-        (r"/json/settings/all/group/(role|instance)$",
-         SettingsGroupAllJsonHandler, handler_conf),
         # Manage groups (users & instances)
         (r"/settings/groups/(role|instance)$", SettingsGroupHandler,
          handler_conf),

--- a/temboardui/handlers/home.py
+++ b/temboardui/handlers/home.py
@@ -1,8 +1,14 @@
 from temboardui.application import get_instances_by_role_name
-from ..web import app, render_template, Redirect
+from ..web import (
+    Redirect,
+    app,
+    anonymous_allowed,
+    render_template,
+)
 
 
 @app.route('/')
+@anonymous_allowed
 def index(request):
     return Redirect('/home')
 
@@ -10,11 +16,7 @@ def index(request):
 @app.route('/home')
 def home(request):
     role = request.current_user
-    if not role:
-        return Redirect('/login')
-
     instances = get_instances_by_role_name(request.db_session, role.role_name)
-
     return render_template(
         'home.html',
         nav=True, role=role, instance_list=instances,

--- a/temboardui/handlers/user.py
+++ b/temboardui/handlers/user.py
@@ -12,6 +12,7 @@ from ..errors import TemboardUIError
 from ..web import (
     Redirect,
     Response,
+    anonymous_allowed,
     app,
     render_template,
 )
@@ -36,6 +37,7 @@ def login_common(db_session, rolename, password):
 
 
 @app.route('/login', methods=['GET', 'POST'])
+@anonymous_allowed
 def login(request):
     if 'GET' == request.method:
         if request.current_user is None:
@@ -64,6 +66,7 @@ def login(request):
 
 
 @app.route(r'/json/login', methods=['POST'])
+@anonymous_allowed
 def json_login(request):
     # Mitigate dictionnaries attacks.
     sleep(1)

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -446,6 +446,11 @@ class WebApplication(TornadoApplication, Blueprint):
 
 
 def make_error(request, code, message):
+    # If ?noerror=1 is set, only return HTTP error code.
+    if "1" == request.handler.get_argument('noerror', None):
+        logger.debug("Hide error %s %s for ?noerror=1.", code, message)
+        return Response(200)
+
     data = dict(code=code, error=message)
 
     # Dirty hack to determine fallback output format

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -132,3 +132,14 @@ def test_make_error(mocker):
 
     assert 'Pouet' == response.body['error']
     assert 401 == response.status_code
+
+    # ?noerror=1 request always has empty 200 response
+    request = mocker.Mock(name='request', path='/json/settings/roles')
+    request.handler.get_argument.return_value = '1'
+    response = make_error(
+        request,
+        code=401, message='Pouet',
+    )
+
+    assert not response.body
+    assert 200 == response.status_code

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -110,3 +110,25 @@ def test_csv():
 
     with pytest.raises(ValueError):
         csvify({'a': 'b'})
+
+
+def test_make_error(mocker):
+    rt = mocker.patch('temboardui.web.render_template')
+    from temboardui.web import make_error
+
+    # Errors are rendered with HTML template
+    response = make_error(
+        mocker.Mock(name='request', path='/home'),
+        code=401, message=None,
+    )
+    assert rt.called is True
+    assert 401 == response.status_code
+
+    # /json request has json errors
+    response = make_error(
+        mocker.Mock(name='request', path='/json/settings/roles'),
+        code=401, message='Pouet',
+    )
+
+    assert 'Pouet' == response.body['error']
+    assert 401 == response.status_code


### PR DESCRIPTION
This PR provides:
- implicit `@login_required`
- flask_security-like decorator to manage access to request
- JSON formatting of errors in `/json`
- Drop tornado.web.asynchronous decorator for `/json/settings/group/(role|instance)` request.