### PR TITLE
Manage variables in route in generic_proxy

### DIFF
--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -352,7 +352,7 @@ class Blueprint(object):
         url = r'(%s)' % url
 
         @self.instance_proxy(url, methods)
-        def generic_instance_proxy(request, path):
+        def generic_instance_proxy(request, path, *args):
             if request.blueprint and request.blueprint.plugin_name:
                 request.instance.check_active_plugin(
                     request.blueprint.plugin_name)


### PR DESCRIPTION
This allows the support of the following:
```python
blueprint.generic_proxy(r'/maintenance/(.*)/schema/(.*)')
```