### PR TITLE
Show login page directly (no modal)

### DIFF
--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -167,10 +167,8 @@ $(function() {
       error: function(xhr) {
         $('#ErrorModal').modal('hide');
         if (xhr.status == 401) {
-          $('#modalError').html(html_error_modal(401, 'Session expired'));
-          $('#ErrorModalFooter').html('<a class="btn btn-outline-secondary" id="aBackLogin">Back to login page</a>');
-          $('#aBackLogin').attr('href', '/server/'+agent_address+'/'+agent_port+'/login');
-          $('#ErrorModal').modal('show');
+          // force a reload of the page, should lead to the server login page
+          location.href = location.href;
         } else {
           var code = xhr.status;
           var error = 'Internal error.';
@@ -316,14 +314,9 @@ $(function() {
           window.location.replace(url);
         },
         error: function(xhr) {
-          if (xhr.status == 401)
-          {
-            $('#ModalInfo').html('<div class="row"><div class="col-12"><div class="alert alert-danger" role="alert">Error: Session expired.</div></div></div>');
-            var footer_html = '';
-            footer_html += '<button type="button" id="buttonBackLogin" class="btn btn-success">Back to login page</button>';
-            footer_html += ' <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cancel</button>';
-            $('#ModalFooter').html(footer_html);
-            $('#buttonBackLogin').attr('href', '/server/'+agent_address+'/'+agent_port+'/login');
+          if (xhr.status == 401) {
+            // force a reload of the page, should lead to the server login page
+            location.href = location.href;
           }
           else
           {

--- a/temboardui/plugins/dashboard/static/js/temboard.dashboard.js
+++ b/temboardui/plugins/dashboard/static/js/temboard.dashboard.js
@@ -42,6 +42,10 @@ $(function() {
       },
       error: function(xhr) {
         $('#ErrorModal').modal('hide');
+        if (xhr.status == 401 || xhr.status == 302) {
+          // force a reload of the page, should lead to the server login page
+          location.href = location.href;
+        }
         var code = xhr.status;
         var error = 'Internal error.';
         if (code > 0) {
@@ -50,11 +54,6 @@ $(function() {
           code = '';
         }
         $('#modalError').html(html_error_modal(code, error));
-
-        if (xhr.status == 401 || xhr.status == 302) {
-          $('#ErrorModalFooter').html('<a class="btn btn-outline-secondary" id="aBackLogin">Back to login page</a>');
-          $('#aBackLogin').attr('href', '/server/'+agent_address+'/'+agent_port+'/login');
-        }
         $('#ErrorModal').modal('show');
       }
     });


### PR DESCRIPTION
Fixes #537 
Because the modal with the link "back to login" is open within an ajax request to proxy, the referer_uri in the cookie is not correctly set.
This PR simplifies the process by reloading the page. This eventually leads to asking the user for agent login without requiring any click on a modal button.