### PR TITLE
Query filter takes precedence over category

### DIFF
--- a/temboardui/plugins/pgconf/__init__.py
+++ b/temboardui/plugins/pgconf/__init__.py
@@ -52,15 +52,18 @@ def configuration_handler(request, category=None):
     if "GET" == request.method:
         status = request.instance.get(prefix + "/status")
         categories = request.instance.get(prefix + "/categories")
-        logger.debug("category=%s", category)
-        if category:
-            category = url_unescape(category)
-        else:
-            category = categories['categories'][0]
 
-        logger.debug("category=%s", category)
-        configuration_url = prefix + "/category/" + url_escape(category)
-        query = {'filter': query_filter} if query_filter else {}
+        if query_filter:
+            query = {'filter': query_filter}
+            configuration_url = prefix
+        else:
+            if category:
+                category = url_unescape(category)
+            else:
+                category = categories['categories'][0]
+            logger.debug("category=%s", category)
+            query = {}
+            configuration_url = prefix + "/category/" + url_escape(category)
         configuration = request.instance.get(configuration_url, query=query)
     else:
         settings = {'settings': [


### PR DESCRIPTION
Broken in 551ee3f52f56c45b05c7e715099029a147de0d2d

The "find in name" filter in the configuration plugin was recently broken. It doesn't search in all categories anymore. The current PR fixes the wrong behavior.