### PR TITLE
Add maintenance to default plugins

### DIFF
--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -217,6 +217,7 @@ class TemboardApplication(BaseApplication):
         'dashboard',
         'monitoring',
         'pgconf',
+        'maintenance',
     ]
     PROGRAM = 'temboard'
     REPORT_URL = "https://github.com/dalibo/temboard/issues"


### PR DESCRIPTION
This prevents errors when using docker in which the list of plugins is not set.