### PR TITLE
Pentest toolkit submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ release:
 upload:
 	@echo Checking we are on a tag
 	git describe --exact-match --tags
+	python2 -c 'import temboardui.toolkit'
 	python2.7 setup.py sdist bdist_wheel
 	twine upload dist/temboard-$(VERSION).tar.gz dist/temboard-$(VERSION)-py2-none-any.whl
 

--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -9,16 +9,18 @@ DESTDIR=$WORKDIR/destdir
 DISTDIR=$(readlink -m dist)
 
 teardown () {
+    set +x
     if [ "0" = "${CLEAN-1}" ] ; then
         return
     fi
 
     rm -rf $WORKDIR
 
-    echo "Cleaning any installation." >&2
     if hash temboard &>/dev/null; then
-        apt-get purge -y temboard
+	echo "Cleaning previous installation." >&2
+        apt-get -qq purge -y temboard
     fi
+    set -x
 }
 trap teardown EXIT INT TERM
 teardown

--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -87,7 +87,11 @@ deb=$(ls temboard_${debianv}-${release}_*.deb)
 dpkg-deb -I $deb
 dpkg-deb -c $deb
 dpkg -i $deb
-(cd /; temboard --version)
+(
+	cd /
+	temboard --version
+	python -c 'import temboardui.toolkit'
+)
 
 #       S A V E
 

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -54,4 +54,9 @@ ln -fs $(basename $rpm) dist/rpm/noarch/last_build.rpm
 
 # Test it
 sudo yum install -y $rpm
-temboard --version
+(
+	cd /;
+	temboard --version;
+	python -c 'import temboardui.toolkit';
+
+)

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -5,6 +5,7 @@ test -f setup.py
 
 teardown() {
 	exit_code=$?
+	set +x;
 	# rpmbuild requires files to be owned by running uid
 	sudo chown --recursive $(id -u):$(id -g) packaging/rpm/
 	rm -f packaging/rpm/temboard*.tar.gz
@@ -15,6 +16,8 @@ teardown() {
 	# on error. This allows user to enter the container and debug after a
 	# build failure.
 	if [ -z "${CI-}" -a $$ = 1 -a $exit_code -gt 0 ] ; then
+		echo "Waiting forever. Debug with" >&2
+		echo "	docker exec -it $(hostname) /bin/bash"
 		tail -f /dev/null
 	fi
 }


### PR DESCRIPTION
cc @julmon 

``` console
+ cd /
+ temboard --version
3.0
+ python -c 'import temboardui.toolkit'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named temboardui.toolkit
+ teardown
+ '[' 0 = 1 ']'
+ rm -rf /workspace/build/debian
+ echo 'Cleaning any installation.'
Cleaning any installation.
+ hash temboard
+ apt-get purge -y temboard
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  temboard*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 32.1 MB disk space will be freed.
(Reading database ... 24569 files and directories currently installed.)
Removing temboard (3.0-0dlb1jessie1) ...
make: *** [Makefile:8: jessie] Error 1
```