### PR TITLE
Set encoding for alert notification email

### DIFF
--- a/temboardui/application.py
+++ b/temboardui/application.py
@@ -748,7 +748,7 @@ def check_agent_port(value):
 
 def send_mail(host, port, subject, content, emails):
 
-    msg = MIMEText(content)
+    msg = MIMEText(content, 'plain', 'utf-8')
     msg['Subject'] = subject
 
     try:


### PR DESCRIPTION
With this change, the arrow is correctly displayed even in plain text.