### PR TITLE
Partition history tables and purge them

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ The configuration file `temboard.conf` is formated using INI format. Configurati
   - `ssl_ca_cert_file `: File where to store each agent's SSL certificate. Default: `/etc/temboard/ssl/temboard_ca_certs_CHANGEME.pem`;
   - `cookie_secret`: Secret key used to crypt cookie content. Default: `SECRETKEYTOBECHANGED`;
   - `plugins`: Array of plugin name to load. Default: `["monitoring", "dashboard", "pgconf", "activity", "maintenance"]`;
+  - `home`: Set home directory for `temboard`. Default: `/var/lib/temboard`
 
 ### `[repository]`
   - `host`: Repository host name or address. Default: `localhost`;
@@ -22,6 +23,7 @@ The configuration file `temboard.conf` is formated using INI format. Configurati
   - `user`: Connection user. Default: `temboard`;
   - `password`: User password. Default: `None`;
   - `dbname`: Database name. Default: `temboard`;
+  - `data_purge`: Automatic purge of older data, in months. Default: `6`
 
 ### `[logging]`
   - `method`: Method used to send the logs: `stderr`, `syslog` or `file`. Default: `syslog`;

--- a/share/temboard.conf
+++ b/share/temboard.conf
@@ -28,6 +28,8 @@ home = /tmp
 # password =
 # Database name.
 # dbname = temboard
+# Purge older data, in months
+# data_purge = 6
 
 [logging]
 # Available methods for logging: stderr, syslog or file

--- a/temboard.dev.conf
+++ b/temboard.dev.conf
@@ -25,6 +25,8 @@ user = temboard
 password = temboard
 # Database name.
 dbname = temboard
+# Purge older data, in months
+data_purge = 6
 
 [logging]
 # Available methods for logging: stderr, syslog or file

--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -209,6 +209,7 @@ def list_options_specs():
     yield OptionSpec(s, 'user', default='temboard')
     yield OptionSpec(s, 'password', default='temboard')
     yield OptionSpec(s, 'dbname', default='temboard')
+    yield OptionSpec(s, 'data_purge', default=6)
 
     s = 'notifications'
     yield OptionSpec(s, 'smtp_host', default=None)

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -122,8 +122,10 @@ def purge_history_worker(app):
         engine = create_engine(dburi)
         with engine.connect() as conn:
             conn.execute("SET search_path TO monitoring")
-            logger.debug("Running SQL function monitoring.purge_history_tables({0})".format(data_purge))
-            res = conn.execute("SELECT * FROM purge_history_tables({0})".format(data_purge))
+            logger.debug("Running SQL function monitoring.purge_history_tables"
+                         "({0})".format(data_purge))
+            res = conn.execute("SELECT * FROM purge_history_tables({0})"
+                               .format(data_purge))
             for row in res.fetchall():
                 logger.debug("table=%s dropped" % (row['tblname']))
             conn.execute("COMMIT")


### PR DESCRIPTION
In this PR is a proposal for history table partition using native partitioning.

Partitions for every history table is created in the format history_table_name_YYYYMM when needed from the history_tables function.

A new configuration key was added: data_purge. 
Any history partition older than this value in months will be dropped.
I ran the purge worker every day (purge_history_tables function).

This version should be tested for some time on a server to check for corner cases.