### PR TITLE
Include pg_track_slow_queries in dev. env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,15 @@ services:
       - ./share/sql/dev-fixture.sql:/docker-entrypoint-initdb.d/90-dev-fixture.sql
 
   instance:
-    image: postgres:10-alpine
+    build:
+      context: .
+      dockerfile: ./docker-dev/Dockerfile.instance
     ports:
       - 5433:5432
     volumes:
       - data:/var/lib/postgresql/data
       - run:/var/run/postgresql
+    command: -c "pg_track_slow_queries.log_min_duration=0" -c "pg_track_slow_queries.cost_analyze=0"
 
   agent:
     image: dalibo/temboard-agent

--- a/docker-dev/Dockerfile.instance
+++ b/docker-dev/Dockerfile.instance
@@ -1,0 +1,6 @@
+FROM postgres:11-alpine
+
+ADD docker-dev/init_pgtsq.sh /docker-entrypoint-initdb.d/
+RUN apk add wget && \
+	wget https://yum.dalibo.org/apk/postgresql_11_pg_track_slow_queries-CURRENT.apk && \
+	apk add --allow-untrusted ./postgresql_11_pg_track_slow_queries-CURRENT.apk

--- a/docker-dev/init_pgtsq.sh
+++ b/docker-dev/init_pgtsq.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Configure shared_preload_libraries
+echo "shared_preload_libraries = 'pg_track_slow_queries'" >> $PGDATA/postgresql.conf
+
+# Restart PG
+pg_ctl -D "$PGDATA" -w stop -m fast
+pg_ctl -D "$PGDATA" -w start
+
+# Create extension on postgres DB
+psql -U postgres -d postgres -c "CREATE EXTENSION pg_track_slow_queries;"


### PR DESCRIPTION
This commit moves the docker image we use for development
from 10-alpine to 11-alpine and updates it to include
pg_track_slow_queries extension.