### PR TITLE
Add more SMTP configuration options

### DIFF
--- a/docs/temboard-howto-alerting.md
+++ b/docs/temboard-howto-alerting.md
@@ -69,17 +69,25 @@ In your `temBoard` configuration file you need to add the following section:
 ```yaml
 [notifications]
 # SMTP host
-smtp_host = localhost
+smtp_host = smtp.gmail.com
 # SMTP port
-# smtp_port =
+smtp_port = 465
+smtp_tls = True
+smtp_login = <email>@gmail.com
+smtp_password = <password>
 
 # Twilio SMS service configuration
-twilio_account_sid = ACCOUNTSIDTOBECHANGED
-twilio_auth_token = AUTHTOKENTOBECHANGED
-twilio_from = FROMNUMBERTOBECHANGED
+twilio_account_sid = <account_id>
+twilio_auth_token = <auth_token>
+twilio_from = <from_number>
 ```
 
 Note: you can leave the settings commented if you don't want to use them.
+
+The above example shows how to configure the SMTP for sending emails via Google
+Mail. The password may be an application password in case you're using
+2-Step-Verification. See [Sign in using App
+Passwords](https://support.google.com/accounts/answer/185833).
 
 For the twilio settings, please refer to [Twilio Usage Documentation](https://www.twilio.com/docs/usage).
 

--- a/share/temboard.conf
+++ b/share/temboard.conf
@@ -45,6 +45,13 @@ level = DEBUG
 # smtp_host = localhost
 # SMTP port
 # smtp_port =
+# SMTP TLS
+# smtp_tls = False
+# SMTP login / password
+# smtp_login =
+# smtp_password =
+# SMTP from address
+# smtp_from_addr =
 # Twilio SMS service configuration
 # twilio_account_sid = ACCOUNTSIDTOBECHANGED
 # twilio_auth_token = AUTHTOKENTOBECHANGED

--- a/temboard.dev.conf
+++ b/temboard.dev.conf
@@ -43,6 +43,13 @@ level = DEBUG
 smtp_host = localhost
 # SMTP port
 # smtp_port =
+# SMTP TLS
+# smtp_tls = False
+# SMTP login / password
+# smtp_login =
+# smtp_password =
+# SMTP from address
+# smtp_from_addr =
 #
 # Twilio SMS service configuration
 # twilio_account_sid = ACCOUNTSIDTOBECHANGED

--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -213,6 +213,10 @@ def list_options_specs():
     s = 'notifications'
     yield OptionSpec(s, 'smtp_host', default=None)
     yield OptionSpec(s, 'smtp_port', default=None)
+    yield OptionSpec(s, 'smtp_tls', default=False)
+    yield OptionSpec(s, 'smtp_login', default=None)
+    yield OptionSpec(s, 'smtp_password', default=None)
+    yield OptionSpec(s, 'smtp_from_addr', default=None)
     yield OptionSpec(s, 'twilio_account_sid', default=None)
     yield OptionSpec(s, 'twilio_auth_token', default=None)
     yield OptionSpec(s, 'twilio_from', default=None)

--- a/temboardui/handlers/settings/notifications.py
+++ b/temboardui/handlers/settings/notifications.py
@@ -32,12 +32,17 @@ def send_test_email(request):
     notifications_conf = app.config.notifications
     smtp_host = notifications_conf.smtp_host
     smtp_port = notifications_conf.smtp_port
+    smtp_tls = notifications_conf.smtp_tls
+    smtp_login = notifications_conf.smtp_login
+    smtp_password = notifications_conf.smtp_password
+    smtp_from_addr = notifications_conf.smtp_from_addr
 
     if not smtp_host:
         raise HTTPError(500, "SMTP server is not configured")
 
     send_mail(smtp_host, smtp_port, 'temBoard notification test',
-              'This is a test', email)
+              'This is a test', email, smtp_tls, smtp_login, smtp_password,
+              smtp_from_addr)
     return {'message': 'OK'}
 
 

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -233,6 +233,10 @@ def notify_state_change(app, check_id, key, value, state, prev_state):
     notifications_conf = app.config.notifications
     smtp_host = notifications_conf.smtp_host
     smtp_port = notifications_conf.smtp_port
+    smtp_tls = notifications_conf.smtp_tls
+    smtp_login = notifications_conf.smtp_login
+    smtp_password = notifications_conf.smtp_password
+    smtp_from_addr = notifications_conf.smtp_from_addr
 
     if not smtp_host and \
        not notifications_conf.get('twilio_account_sid', None):
@@ -316,7 +320,8 @@ def notify_state_change(app, check_id, key, value, state, prev_state):
 
     emails = [role.role_email for role in roles if role.role_email]
     if len(emails):
-        send_mail(smtp_host, smtp_port, subject, body, emails)
+        send_mail(smtp_host, smtp_port, subject, body, emails, smtp_tls,
+                  smtp_login, smtp_password,  smtp_from_addr)
 
     phones = [role.role_phone for role in roles if role.role_phone]
     if len(phones):


### PR DESCRIPTION
Example of configuration working with gmail SMTP:
```ini
[notifications]
# SMTP host
smtp_host = smtp.gmail.com
# SMTP port
smtp_port = 465
smtp_tls = True
smtp_login = <email>@gmail.com
smtp_password = <password>
```