### PR TITLE
Prevent endless chart height increase on Chrome 75

### DIFF
--- a/temboardui/plugins/dashboard/templates/dashboard.html
+++ b/temboardui/plugins/dashboard/templates/dashboard.html
@@ -130,7 +130,7 @@
           </span>
           <div class="position-absolute top-0 right-0 pr-1"><span id="loadaverage" class="badge badge-primary">{{dashboard['loadaverage']}}</span></div>
         </div>
-        <div class="card-body h-100 p-2">
+        <div class="card-body p-2">
           <div id="canvas-loadaverage-holder" class="canvas-wrapper chart-h-min chart-h-min-xl-0">
             <canvas id="chart-loadaverage" />
           </div>
@@ -145,7 +145,7 @@
           </span>
           <div class="position-absolute top-0 right-0 pr-1">Commit: <span id="tps_commit" class="badge badge-success">0</span> Rollback: <span id="tps_rollback" class="badge badge-danger">0</span></div>
         </div>
-        <div class="card-body h-100 p-2">
+        <div class="card-body p-2">
           <div id="canvas-tps-holder" class="canvas-wrapper chart-h-min chart-h-min-xl-0">
             <canvas id="chart-tps"/>
           </div>


### PR DESCRIPTION
![Capture du 2019-06-25 17-10-27](https://user-images.githubusercontent.com/319774/60110307-2dabb280-976c-11e9-97b5-053fcda04c86.png)

".card-body" is already using the available height. ".h-100" is not required.
Things are messing up in Chrome 75 when ChartJS tries to monitor the chart container size.