### PR TITLE
Allow instance to be updated even when agent unreachable

### DIFF
--- a/temboardui/application.py
+++ b/temboardui/application.py
@@ -391,12 +391,12 @@ def update_instance(session,
             instance.pg_port = int(pg_port)
         else:
             instance.pg_port = None
-        instance.agent_key = unicode(agent_key)
-        instance.hostname = unicode(hostname)
-        instance.pg_version = unicode(pg_version)
-        instance.pg_version_summary = unicode(pg_version_summary)
-        instance.pg_data = unicode(pg_data)
         instance.notify = bool(notify)
+
+        for prop in ['agent_key', 'hostname', 'pg_version',
+                     'pg_version_summary', 'pg_data']:
+            if locals().get(prop) is not None:
+                setattr(instance, prop, unicode(locals().get(prop)))
         session.merge(instance)
         session.flush()
         return instance

--- a/temboardui/handlers/settings/instance.py
+++ b/temboardui/handlers/settings/instance.py
@@ -64,20 +64,6 @@ def validate_instance_data(data):
     check_agent_port(data['new_agent_port'])
     if 'agent_key' not in data:
         raise HTTPError(400, "Agent key field is missing.")
-    if 'hostname' not in data:
-        raise HTTPError(400, "Hostname field is missing.")
-    if 'cpu' not in data:
-        raise HTTPError(400, "CPU field is missing.")
-    if 'memory_size' not in data:
-        raise HTTPError(400, "Memory size field is missing.")
-    if 'pg_port' not in data:
-        raise HTTPError(400, "PostgreSQL port field is missing.")
-    if 'pg_version' not in data:
-        raise HTTPError(400, "PostgreSQL version field is missing.")
-    if 'pg_version_summary' not in data:
-        raise HTTPError(400, "PostgreSQL version summary field is missing.")
-    if 'pg_data' not in data:
-        raise HTTPError(400, "PostgreSQL data directory field is missing.")
     if 'groups' not in data:
         raise HTTPError(400, "Groups field is missing.")
     if data['groups'] is not None and type(data['groups']) != list:

--- a/temboardui/templates/settings/instance.html
+++ b/temboardui/templates/settings/instance.html
@@ -79,6 +79,7 @@
     </table>
   </div>
 </div>
+<script src="/js/lodash.min.js"></script>
 <script src="/js/temboard.settings.instance.js"></script>
 <script src="/js/datatables/datatables.min.js"></script>
 <script src="/js/bootstrap-multiselect.js"></script>


### PR DESCRIPTION
The idea is to be able to update the instance (ie. change the groups, notification flag, …) even if the agent is unreachable thus that we can't discover information for the instance.

It's for now impossible to do the same when adding a new instance because we need to know the hostname which comes from the agent discover service.