### PR TITLE
Do not mound docker binary in Docker agent service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     volumes:
       - data:/var/lib/postgresql/data
       - run:/var/run/postgresql
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - instance:instance.fqdn


### PR DESCRIPTION
Instead, we now rely on docker.io being installed in the agent (see
commit ce795de90c9a99a0f503dd6146d5f2e70060c580 in temboard-agent). A
new dalibo/temboad-agent Docker image will be needed after that.

This should make things work for people using the docker.io package from
Debian (in contrast with, e.g., docker-ce from docker.com's repository).