### PR TITLE
Give instance a superuser and password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     image: postgres:12-alpine
     ports:
       - 5433:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     volumes:
       - data:/var/lib/postgresql/data
       - run:/var/run/postgresql


### PR DESCRIPTION
Prevents error with new postgres alpine images, ie.

Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".