### PR TITLE
Help launching multiple agent in dev env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,20 @@ grunt watch
 ```
 
 
+## Launching Multiple Agents
+
+Default development environment instanciate a single PostgreSQL instance and
+it's temBoard agent. Root Makefile offers two targets to help testing bigger
+infrastructure :
+
+- `make mass-agents` loops from 2345 to 2400 and instanciate a PostgreSQL
+  instance and an agent to monitor it. Each instanciation requires you to type
+  `y`. This allows to throttle instanciations and to stop when enough instances
+  are up.
+- `make clean-agents` trashes every existings instances from 2345 to 2400,
+  without interaction. **Agent are not unregistered!**
+
+
 # Coding style
 
 A `.editorconfig` file is included at the root of the repository configuring

--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -1,0 +1,40 @@
+# This compose file requires a few environment variables, see root Makefile for
+# details.
+version: '3'
+
+networks:
+  # By default, hook containers in network managed by root docker-compose.yml
+  default:
+    external:
+      name: ${NETWORK}
+
+volumes:
+  data:
+  run:
+
+services:
+  instance:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_PASSWORD: confinment
+    volumes:
+    - data:/var/lib/postgresql/data
+    - run:/var/run/postgresql
+
+  agent:
+    image: dalibo/temboard-agent
+    ports:
+      - ${TEMBOARD_REGISTER_PORT}:2345
+    volumes:
+      - data:/var/lib/postgresql/data
+      - run:/var/run/postgresql
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - instance:instance-${TEMBOARD_REGISTER_PORT}.fqdn
+    environment:
+      TEMBOARD_HOSTNAME: instance-${TEMBOARD_REGISTER_PORT}.fqdn
+      TEMBOARD_KEY: key_for_agent0
+      TEMBOARD_UI_URL: https://172.17.0.1:8888
+      TEMBOARD_REGISTER_HOST: 172.17.0.1
+      TEMBOARD_REGISTER_PORT: ${TEMBOARD_REGISTER_PORT}
+      TEMBOARD_GROUPS: default


### PR DESCRIPTION
Instanciating a variable number of agent by hand is cumbersome. To ease
development ofr bigger infrastructure eases the instancation of multiple
agents in development environement.