### PR TITLE
Post-release version bump

### DIFF
--- a/temboardui/version.py
+++ b/temboardui/version.py
@@ -3,7 +3,7 @@ import sys
 from platform import python_version
 
 
-__version__ = "5.0+master"
+__version__ = "6.0.alpha0+master"
 
 
 VERSION_FMT = """\


### PR DESCRIPTION
Avec ce numéro, on a 5.0 < 6.0.alpha0 < 6.0. Le +master permet de détecter une installation depuis les sources et non depuis un paquet.

``` python
>>> from pkg_resources import parse_version
>>> parse_version('5.0') < parse_version('6.0.alpha0+master') < parse_version('6.0')
True
>>>
```