### PR TITLE
Load entrypoint plugins along side legacy plugins

### DIFF
--- a/temboardui/__main__.py
+++ b/temboardui/__main__.py
@@ -77,7 +77,7 @@ def filter_legacy_plugins(plugins_names):
         try:
             fp, pathname, description = imp.find_module(plugin_name,
                                                         [path + '/plugins'])
-        except ImportError as e:
+        except ImportError:
             continue
 
         if fp:


### PR DESCRIPTION
BaseApplication has everything needed to use plugins installed with
setuptools but it conflicts with "legacy" plugins. This patch gives the
proper list of plugins to load depending on their kind to the
corresponding loading code.