### PR TITLE
devenv - Wait for postgresql to start a bit more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ renew_sslcert:
 
 devenv:
 	docker-compose up -d repository
-	sleep 1
+	sleep 2
 	PGPASSWORD=temboard PGUSER=temboard psql -t -h 0.0.0.0 -c 'SELECT version();' "connect_timeout=15"
 	PGPASSWORD=temboard PGUSER=temboard PGHOST=0.0.0.0 DEV=1 share/create_repository.sh
 	docker-compose up -d


### PR DESCRIPTION
On my (rather slow) computer, 1 second is never enough for the repository to be started. I have to relaunch the command twice. With 2 seconds it's better.