### PR TITLE
Log error message when alert process fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Default configuration file is not required, by [@bersace].
+- Log error message when alert processing fails, by [@bersace].
 
 
 ## [5.0] - 2020-04-16

--- a/temboardui/plugins/monitoring/tools.py
+++ b/temboardui/plugins/monitoring/tools.py
@@ -257,9 +257,9 @@ def preprocess_data(data, checks, timestamp):
 
         try:
             res = spec.get('preprocess')(data)
-        except Exception:
+        except Exception as e:
             logger.warning(
-                "Failed to preprocess alerting check '%s'", check[0]
+                "Failed to preprocess alerting check '%s': %s", check[0], e,
             )
             continue
 


### PR DESCRIPTION
Avoid meaningless message such as:

    [monitoring.tools] WARNING: Failed to preprocess alerting check 'replication_lag'