### PR TITLE
Fix double loading of monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Full PostgreSQL 12 support, including monitoring and configuration, by [@pgiraud].
+- Double loading of legacy plugins, by [@bersace].
 
 ### Changed
 

--- a/temboardui/plugins/activity/__init__.py
+++ b/temboardui/plugins/activity/__init__.py
@@ -7,6 +7,7 @@ from temboardui.web import (
 )
 
 
+PLUGIN_NAME = 'activity'
 blueprint = Blueprint()
 blueprint.generic_proxy(r'/activity/kill', methods=['POST'])
 plugin_path = path.dirname(path.realpath(__file__))
@@ -35,7 +36,7 @@ def get_agent_username(request):
 
 @blueprint.instance_route(r'/activity/(running|blocking|waiting)')
 def activity(request, mode):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     agent_username = get_agent_username(request)
     xsession = request.instance.xsession if agent_username else None
     return render_template(
@@ -43,7 +44,7 @@ def activity(request, mode):
         nav=True,
         agent_username=agent_username,
         instance=request.instance,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         mode=mode,
         xsession=xsession,
         role=request.current_user,
@@ -52,7 +53,7 @@ def activity(request, mode):
 
 @blueprint.instance_proxy(r'/activity(?:/blocking|/waiting)?')
 def activity_proxy(request):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     return dict(
         blocking=request.instance.get('/activity/blocking'),
         running=request.instance.get('/activity'),

--- a/temboardui/plugins/dashboard/__init__.py
+++ b/temboardui/plugins/dashboard/__init__.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 plugin_path = realpath(__file__ + '/..')
 render_template = TemplateRenderer(plugin_path + '/templates')
 
+PLUGIN_NAME = 'dashboard'
+
 
 def configuration(config):
     return {}
@@ -33,7 +35,7 @@ def get_routes(config):
 
 @blueprint.instance_route(r"/dashboard")
 def dashboard(request):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
 
     try:
         agent_username = request.instance.get_profile()['username']
@@ -62,7 +64,7 @@ def dashboard(request):
         nav=True, role=request.current_user,
         instance=request.instance,
         agent_username=agent_username,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         config=json_encode(config),
         dashboard=last_data,
         history=json_encode(history or ''),

--- a/temboardui/plugins/maintenance/__init__.py
+++ b/temboardui/plugins/maintenance/__init__.py
@@ -7,6 +7,7 @@ from temboardui.web import (
 )
 
 
+PLUGIN_NAME = 'maintenance'
 blueprint = Blueprint()
 blueprint.generic_proxy(r'/maintenance/.*/schema/.*/table/.*/'
                         '(?:vacuum|analyze)',
@@ -51,20 +52,20 @@ def get_agent_username(request):
 
 @blueprint.instance_route(r'/maintenance')
 def maintenance(request):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     return render_template(
         'index.html',
         nav=True,
         agent_username=get_agent_username(request),
         instance=request.instance,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         role=request.current_user,
     )
 
 
 @blueprint.instance_route(r'/maintenance/(.*)/schema/(.*)/table/(.*)')
 def table(request, database, schema, table):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     agent_username = get_agent_username(request)
     xsession = request.instance.xsession if agent_username else None
     return render_template(
@@ -72,7 +73,7 @@ def table(request, database, schema, table):
         nav=True,
         agent_username=agent_username,
         instance=request.instance,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         xsession=xsession,
         role=request.current_user,
         database=database,
@@ -83,7 +84,7 @@ def table(request, database, schema, table):
 
 @blueprint.instance_route(r'/maintenance/(.*)/schema/(.*)')
 def schema(request, database, schema):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     agent_username = get_agent_username(request)
     xsession = request.instance.xsession if agent_username else None
     return render_template(
@@ -91,7 +92,7 @@ def schema(request, database, schema):
         nav=True,
         agent_username=agent_username,
         instance=request.instance,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         xsession=xsession,
         role=request.current_user,
         database=database,
@@ -101,7 +102,7 @@ def schema(request, database, schema):
 
 @blueprint.instance_route(r'/maintenance/(.*)')
 def database(request, database):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     agent_username = get_agent_username(request)
     xsession = request.instance.xsession if agent_username else None
     return render_template(
@@ -109,7 +110,7 @@ def database(request, database):
         nav=True,
         agent_username=get_agent_username(request),
         instance=request.instance,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         xsession=xsession,
         role=request.current_user,
         database=database,

--- a/temboardui/plugins/monitoring/__init__.py
+++ b/temboardui/plugins/monitoring/__init__.py
@@ -51,6 +51,7 @@ from .tools import (
 )
 
 logger = logging.getLogger(__name__)
+PLUGIN_NAME = 'monitoring'
 workers = taskmanager.WorkerSet()
 
 

--- a/temboardui/plugins/monitoring/handlers/monitoring.py
+++ b/temboardui/plugins/monitoring/handlers/monitoring.py
@@ -28,7 +28,7 @@ from ..tools import (
 )
 from ..model.db import insert_availability
 
-logger = logging.getLogger('temboardui.plugins.' + __name__)
+logger = logging.getLogger(__name__)
 
 
 def check_agent_request(request, hostname, instance):

--- a/temboardui/plugins/pgconf/__init__.py
+++ b/temboardui/plugins/pgconf/__init__.py
@@ -11,6 +11,7 @@ from temboardui.web import (
 )
 
 
+PLUGIN_NAME = 'pgconf'
 logger = logging.getLogger(__name__)
 blueprint = Blueprint()
 blueprint.generic_proxy("/pgconf/configuration", methods=["POST"])
@@ -41,7 +42,7 @@ def get_routes(config):
 @blueprint.instance_route("/pgconf/configuration(?:/category/(.+))?",
                           methods=["GET", "POST"])
 def configuration_handler(request, category=None):
-    request.instance.check_active_plugin(__name__)
+    request.instance.check_active_plugin(PLUGIN_NAME)
     profile = request.instance.get_profile()
     agent_username = profile['username']
     template_vars = {}
@@ -88,7 +89,7 @@ def configuration_handler(request, category=None):
         role=request.current_user,
         instance=request.instance,
         agent_username=agent_username,
-        plugin=__name__,
+        plugin=PLUGIN_NAME,
         xsession=request.instance.xsession,
         current_cat=category,
         configuration_categories=categories,


### PR DESCRIPTION
`temboardui/plugins/monitoring/__init__.py` was loaded once by imp.load_module with `__name__` `monitoring` and a second time by `temboardui/plugins/monitoring/model/orm.py` with `__name__`
`temboardui.plugins.monitoring`.

Now, always load plugins with full module name.