### PR TITLE
deb: Buster support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,16 @@ workflows:
         name: stage0-pkg-<< matrix.codename >>
         matrix:
           parameters:
-            codename: [stretch, jessie]
+            codename: [buster, stretch, jessie]
     - func:
         name: stage1-func-pg12-centos7
         requires: [stage0-unit]
         dist: centos7
         pgversion: "12"
     - func:
-        name: stage1-func-pg9.5-stretch
+        name: stage1-func-pg9.5-buster
         requires: [stage0-unit]
-        dist: stretch
+        dist: buster
         pgversion: "9.5"
 
 jobs:
@@ -94,7 +94,7 @@ jobs:
       codename:
         description: "Debian version"
         type: enum
-        enum: [stretch, jessie]
+        enum: [buster, stretch, jessie]
     docker: [{image: "dalibo/temboard-agent-sdk:<< parameters.codename >>"}]
     working_directory: ~/workspace
     steps:
@@ -116,7 +116,7 @@ jobs:
       dist:
         description: "Distribution"
         type: enum
-        enum: [stretch, jessie, centos7]
+        enum: [buster, stretch, jessie, centos7]
       pgversion:
         description: "PostgreSQL version for repository."
         type: enum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   [@bersace].
 - temBoard repository schema is now versionned, by [@bersace].
 - Load external plugins from setuptools entrypoint `temboard.plugins`, by [@orgrim].
+- Debian Buster testing & packaging, by [@bersace].
 
 ### Fixed
 

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -1,9 +1,9 @@
 DISTDIR=../../dist
 DPUT=labs
 
-all: jessie stretch
+all: buster jessie stretch
 
-jessie stretch:
+buster jessie stretch:
 	mkdir -p $(DISTDIR)
 	docker-compose run --rm $@
 	./mkchanges.sh $$(readlink -e $(DISTDIR)/last_build.deb) $@

--- a/packaging/deb/docker-compose.yml
+++ b/packaging/deb/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 
 services:
-  stretch: &mkdeb
-    image: dalibo/temboard-agent-sdk:stretch
+  buster: &mkdeb
+    image: dalibo/temboard-agent-sdk:buster
     environment:
       # See dch(1)
       DEBFULLNAME: ${DEBFULLNAME}
@@ -10,6 +10,10 @@ services:
     volumes:
     - ../..:/workspace
     command: /workspace/packaging/deb/mkdeb.sh
+
+  stretch:
+    <<: *mkdeb
+    image: dalibo/temboard-agent-sdk:stretch
 
   jessie:
     <<: *mkdeb

--- a/tests/func/docker-compose.yml
+++ b/tests/func/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: selenium/standalone-firefox
 
   ui:
-    image: dalibo/temboard-agent-sdk:${TAG-stretch}
+    image: dalibo/temboard-agent-sdk:${TAG-buster}
     environment:
       HISTFILE: /workspace/tests/func/.docker-cache/bash_history
       PGHOST: repository


### PR DESCRIPTION
Switch main debian codename to buster and still build stretch package.