### PR TITLE
Fix filter when groups query param is empty in URL

### DIFF
--- a/temboardui/static/js/home.js
+++ b/temboardui/static/js/home.js
@@ -68,10 +68,9 @@ $(function() {
     el: '#instances',
     router: new VueRouter(),
     data: function() {
-      try {
-        var groupsFilter = this.$route.query.groups.split(',');
-      } catch (e) {
-        var groupsFilter = [];
+      var groupsFilter = [];
+      if (this.$route.query.groups) {
+        groupsFilter = this.$route.query.groups.split(',');
       }
       return {
         instances: instances,


### PR DESCRIPTION
Currently if one loads `https://my.temboard/home#/?groups=` the instance list is empty and the group chooser displays "groups (1)".
This happens after a user selects one group and then deselects it.