### PR TITLE
Use old syntax for port for smtp service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,5 +44,6 @@ services:
 
   smtp:
     image: python:3
-    ports: [8025:8025]
+    ports:
+      - 8025:8025
     command: [python3, -m, smtpd, --debug, --nosetuid, --class, DebuggingServer]


### PR DESCRIPTION
On my machine, I get the following error:
```
ERROR: yaml.scanner.ScannerError: while scanning a plain scalar
  in "./docker-compose.yml", line 47, column 13
found unexpected ':'
  in "./docker-compose.yml", line 47, column 17
Please check http://pyyaml.org/wiki/YAMLColonInFlowContext for details.
```

I'm running `docker-compose version 1.22.0, build f46880fe`.