### PR TITLE
Activity save filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Improved performance of the home page (instances list), by [@pgiraud]
+- Activity filters are kept, by [@pgiraud]
 
 ### Fixed
 

--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -361,6 +361,17 @@ $(function() {
 
   var searchFilter = $('#searchFilter');
   searchFilter.keyup(table.draw);
+
+  var initSearchFilter = localStorage.getItem('temboardActivitySearchFilter');
+  if (initSearchFilter) {
+    searchFilter.val(initSearchFilter);
+
+  }
+  // Store in localStorage the states filter selection
+  searchFilter.keyup(function() {
+    localStorage.setItem('temboardActivitySearchFilter', searchFilter.val());
+  });
+
   /* Custom filtering function */
   $.fn.dataTable.ext.search.push(
     function searchFilterFn(settings, data) {

--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -325,7 +325,7 @@ $(function() {
 
   var stateFilters = $('#state-filter input[type=checkbox]');
 
-  function getStateFilters() {
+  function getCheckedStateFilters() {
     var states = [];
     stateFilters.each(function(index, el) {
       var input = $(el);
@@ -348,13 +348,17 @@ $(function() {
 
   // Store in localStorage the states filter selection
   stateFilters.change(function() {
-    localStorage.setItem('temboardActivityStateFilters', JSON.stringify(getStateFilters()));
+    if (stateFilters.length != getCheckedStateFilters().length) {
+      localStorage.setItem('temboardActivityStateFilters', JSON.stringify(getCheckedStateFilters()));
+    } else {
+      localStorage.removeItem('temboardActivityStateFilters');
+    }
   });
 
   /* State filtering function */
   $.fn.dataTable.ext.search.push(
     function stateFilter(settings, data, index, rawData) {
-      var states = getStateFilters();
+      var states = getCheckedStateFilters();
       return states.indexOf(rawData.state) > -1;
     }
   );
@@ -365,11 +369,15 @@ $(function() {
   var initSearchFilter = localStorage.getItem('temboardActivitySearchFilter');
   if (initSearchFilter) {
     searchFilter.val(initSearchFilter);
-
   }
   // Store in localStorage the states filter selection
   searchFilter.keyup(function() {
-    localStorage.setItem('temboardActivitySearchFilter', searchFilter.val());
+    var search = searchFilter.val();
+    if (search) {
+      localStorage.setItem('temboardActivitySearchFilter', searchFilter.val());
+    } else {
+      localStorage.removeItem('temboardActivitySearchFilter');
+    }
   });
 
   /* Custom filtering function */
@@ -386,6 +394,10 @@ $(function() {
       return false;
     }
   );
+
+  if (initStateFilters || searchFilter.val()) {
+    $('#filters').collapse('show');
+  }
 
   /**
    * Find the index of the column for a given title

--- a/temboardui/plugins/activity/static/js/temboard.activity.js
+++ b/temboardui/plugins/activity/static/js/temboard.activity.js
@@ -324,18 +324,37 @@ $(function() {
   });
 
   var stateFilters = $('#state-filter input[type=checkbox]');
+
+  function getStateFilters() {
+    var states = [];
+    stateFilters.each(function(index, el) {
+      var input = $(el);
+      if (input.prop('checked')) {
+        states.push(input.val());
+      }
+    });
+    return states;
+  }
   stateFilters.change(table.draw);
+
+  var initStateFilters = localStorage.getItem('temboardActivityStateFilters');
+  if (initStateFilters) {
+    initStateFilters = JSON.parse(initStateFilters);
+    stateFilters.each(function(index, el) {
+      var input = $(el);
+      input.prop('checked', initStateFilters.indexOf(input.val()) != -1);
+    });
+  }
+
+  // Store in localStorage the states filter selection
+  stateFilters.change(function() {
+    localStorage.setItem('temboardActivityStateFilters', JSON.stringify(getStateFilters()));
+  });
 
   /* State filtering function */
   $.fn.dataTable.ext.search.push(
     function stateFilter(settings, data, index, rawData) {
-      var states = [];
-      stateFilters.each(function(index, el) {
-        var input = $(el);
-        if (input.prop('checked')) {
-          states.push(input.val());
-        }
-      });
+      var states = getStateFilters();
       return states.indexOf(rawData.state) > -1;
     }
   );


### PR DESCRIPTION
Fixes #471 

This makes sure that search or state filters are kept from one tab to another. It also makes sure that the filters panel is visible at page load in case the filters have been changed previously.