### PR TITLE
Not activated plugin

### DIFF
--- a/temboardui/plugins/monitoring/handlers/monitoring.py
+++ b/temboardui/plugins/monitoring/handlers/monitoring.py
@@ -7,6 +7,7 @@ from temboardui.web import (
     csvify,
 )
 
+from .. import PLUGIN_NAME
 from . import blueprint, render_template
 from ..chartdata import (
     get_unavailability_csv,
@@ -123,6 +124,7 @@ def collector(request):
 
 @blueprint.instance_route("/monitoring")
 def index(request):
+    request.instance.check_active_plugin(PLUGIN_NAME)
     try:
         agent_username = request.instance.get_profile()['username']
     except Exception:

--- a/temboardui/web.py
+++ b/temboardui/web.py
@@ -278,7 +278,7 @@ class InstanceHelper(object):
         Ensure that the plugin is active for given instance
         '''
         if name not in [p.plugin_name for p in self.instance.plugins]:
-            raise HTTPError(408, "Plugin not activated.")
+            raise HTTPError(408, "Plugin %s not activated." % name)
 
     def fetch_instance(self, address, port):
         self.instance = get_instance(self.request.db_session, address, port)


### PR DESCRIPTION
Currently all plugins except `monitoring` show an 'plugin not activated' error.
This PR also gives the name of the deactivated plugin in the error message.