### PR TITLE
docs: Fix temboard-migratedb command

### DIFF
--- a/docs/temboard-upgrade-5-6.0.md
+++ b/docs/temboard-upgrade-5-6.0.md
@@ -21,7 +21,7 @@ updates a lot.
 The `repository` database schema must be stamped to the latest version with:
 
 ``` shell
-$ temboard-migratedb stamp
+$ sudo -u temboard temboard-migratedb stamp
 ```
 
 Start `temboard` service:


### PR DESCRIPTION
Suggest running it as temboard, the UNIX user running temboard UI
service.

Cherry-picked from v6 branch.