### PR TITLE
Handle old and new agents way to format enums type settings

### DIFF
--- a/temboardui/plugins/pgconf/templates/configuration.html
+++ b/temboardui/plugins/pgconf/templates/configuration.html
@@ -160,7 +160,12 @@
                 <input id="hidden{{setting_row['name']}}" type="hidden" name="{{setting_row['name']}}" value="{% if setting_row['setting'] == 'on' %}on{%else%}off{% end %}" />
               </div>
               {% elif setting_row['vartype'] == 'enum' %}
-              <select class="form-control form-control-sm" name="{{setting_row['name']}}" id="select{{setting_row['name']}}">{% for v in setting_row['enumvals'][1:-1].split(',') %}<option value="{{v}}" {% if (v.startswith('"') and v.endswith('"') and setting_row['setting'] == v[1:-1]) or setting_row['setting'] == v %} selected="selected"{% end %}>{{v}}</option>{% end %}</select>
+              {% set values = setting_row['enumvals'] %}
+              {# depending on agent version (using psycopg2 or not) values may be a list or coma separated string #}
+              {% if not isinstance(values, list) %}
+              {% set values = values[1:-1].split(',') %}
+              {% end %}
+              <select class="form-control form-control-sm" name="{{setting_row['name']}}" id="select{{setting_row['name']}}">{% for v in values %}<option value="{{v}}" {% if (v.startswith('"') and v.endswith('"') and setting_row['setting'] == v[1:-1]) or setting_row['setting'] == v %} selected="selected"{% end %}>{{v}}</option>{% end %}</select>
               {% else %}
               <input data-toggle="popover" data-trigger="hover" data-placement="top" data-html="true" data-content="<table><tr><td>Type:</td><td><b>{{setting_row['vartype']}}</b></td></tr>{% if setting_row['unit'] %}<tr><td>Unit:</td><td><b>{{setting_row['unit']}}</b></td></tr>{% end %}{% if setting_row['vartype'] in ['integer', 'real'] %}<tr><td>Minimum:</td><td><b>{{setting_row['min_val']}}</b></td></tr><tr><td>Maximum:</td><td><b>{{setting_row['max_val']}}{% end %}</b></td></tr></table>" type="text" class="form-control form-control-sm" name="{{setting_row['name']}}" id="input{{setting_row['name']}}" placeholder="{{setting_row['name']}}" value="{%if setting_row['setting'] is not None%}{{setting_row['setting_raw']}}{%end%}">
               {% end %}


### PR DESCRIPTION
In new agents (w/ psycopg2) enums is a list
whereas in old agents enums is a string to split