### PR TITLE
Clean up indexes in statements plugin

### DIFF
--- a/temboardui/model/alembic/versions/20200824_2dd2ec76ec2c11_clean_up_of_indexes_for_statements.py
+++ b/temboardui/model/alembic/versions/20200824_2dd2ec76ec2c11_clean_up_of_indexes_for_statements.py
@@ -1,0 +1,28 @@
+"""Clean up of indexes for statements
+
+Revision ID: d2ec76ec2c11
+Revises: 3f789ade4fa7
+Create Date: 2020-08-24 10:47:50.095304
+
+"""
+import os.path
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd2ec76ec2c11'
+down_revision = '3f789ade4fa7'
+branch_labels = None
+depends_on = None
+
+
+def sqlfile(name):
+    directory = os.path.dirname(__file__)
+    with open(os.path.join(directory, name + '.sql')) as fo:
+        return sa.text(fo.read())
+
+
+def upgrade():
+    op.get_bind().execute(sqlfile("20200824_statements_indexes_cleanup"))

--- a/temboardui/model/alembic/versions/20200824_statements_indexes_cleanup.sql
+++ b/temboardui/model/alembic/versions/20200824_statements_indexes_cleanup.sql
@@ -1,0 +1,18 @@
+SET search_path = 'statements';
+
+DROP INDEX IF EXISTS statements_history_agent_address_agent_port_dbid_coalesce_r_idx;
+DROP INDEX IF EXISTS statements_history_agent_address_agent_port_queryid_coalesc_idx;
+DROP INDEX IF EXISTS statements_history_current_agent_address_agent_port_dbid_us_idx;
+ALTER TABLE statements_history_current
+DROP CONSTRAINT IF EXISTS statements_history_current_agent_address_agent_port_queryid_key;
+DROP INDEX IF EXISTS statements_history_current_db_agent_address_agent_port_dbid_idx;
+DROP INDEX IF EXISTS statements_history_current_db_agent_address_agent_port_idx;
+ALTER TABLE statements_history_current_db
+DROP CONSTRAINT IF EXISTS statements_history_current_db_agent_address_agent_port_dbid_key;
+DROP INDEX IF EXISTS statements_history_db_agent_address_agent_port_dbid_coalesc_idx;
+DROP INDEX IF EXISTS statements_history_current_db_tstzrange_idx;
+DROP INDEX IF EXISTS statements_history_current_tstzrange_idx;
+
+CREATE INDEX ON statements_history_current (agent_address, agent_port, dbid);
+CREATE INDEX ON statements_history (agent_address, agent_port, dbid);
+CREATE INDEX ON statements_history USING GIST (coalesce_range);


### PR DESCRIPTION
Most of the previously created indexes are useless (don't improve queries)
and use a lot of space + are easily bloated