### PR TITLE
Read PG vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Statements plugin by [@pgiraud] and [@dlax]
+- Load `PG*` vars, by [@bersace].
 
 ### Changed
 

--- a/temboardui/migratedb.py
+++ b/temboardui/migratedb.py
@@ -9,7 +9,7 @@ import alembic.command
 import alembic.config
 import sqlalchemy.exc
 
-from .__main__ import VersionAction
+from .__main__ import VersionAction, map_pgvars
 from .model import build_alembic_config, check_schema
 from .toolkit import validators as v
 from .toolkit.app import (
@@ -41,6 +41,7 @@ class MigrateDBApplication(BaseApplication):
         )
         define_arguments(parser)
         args = parser.parse_args(argv)
+        environ = map_pgvars(environ)
         self.bootstrap(args=args, environ=environ)
 
         versions = inspect_versions()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,3 +1,6 @@
+# coding: utf-8
+
+
 def test_arguments():
     from argparse import ArgumentParser
     from temboardui.__main__ import define_arguments
@@ -8,3 +11,25 @@ def test_arguments():
     args = parser.parse_args(['--pid-file', 'my.pid'])
 
     assert 'my.pid' == args.temboard_pidfile
+
+
+def test_pgvar_map():
+    from temboardui.migratedb import map_pgvars
+
+    env = dict(
+        PGHOST='localhost',
+        PGPORT='5433',
+        PGUSER='temboard',
+        PGPASSWORD='étagère',
+        PGDATABASE='temboarddb',
+    )
+    mapped = map_pgvars(env)
+    assert 'localhost' == mapped['TEMBOARD_REPOSITORY_HOST']
+    assert '5433' == mapped['TEMBOARD_REPOSITORY_PORT']
+    assert 'temboard' == mapped['TEMBOARD_REPOSITORY_USER']
+    assert 'étagère' == mapped['TEMBOARD_REPOSITORY_PASSWORD']
+    assert 'temboarddb' == mapped['TEMBOARD_REPOSITORY_DBNAME']
+
+    env = dict(PGHOST='pg', TEMBOARD_REPOSITORY_HOST='temboard')
+    mapped = map_pgvars(env)
+    assert 'temboard' == mapped['TEMBOARD_REPOSITORY_HOST']


### PR DESCRIPTION
Moving to temboard-migratedb from psql dropped support for PG vars.
Restore this behaviour by reading PG vars in temboard-migratedb script.

Backports #825 