### PR TITLE
Use 'total_exec_time' column if available instead of 'total_time'

### DIFF
--- a/temboardui/plugins/statements/__init__.py
+++ b/temboardui/plugins/statements/__init__.py
@@ -646,7 +646,9 @@ def add_statement(session, instance, data):
                     statement['queryid'],
                     statement['query'],
                     statement['calls'],
-                    statement['total_time'],
+                    statement['total_exec_time']
+                    if 'total_exec_time' in statement
+                    else statement['total_time'],
                     statement['rows'],
                     statement['shared_blks_hit'],
                     statement['shared_blks_read'],


### PR DESCRIPTION
Avoids errors with PG13
Also see https://github.com/dalibo/temboard-agent/pull/459