### PR TITLE
Fix alerting check page after to match daterangepicker update

### DIFF
--- a/temboardui/plugins/monitoring/templates/alerting.check.html
+++ b/temboardui/plugins/monitoring/templates/alerting.check.html
@@ -11,7 +11,7 @@
         <li class="breadcrumb-item"><a href="../alerting">Status</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{check['description']}}</li>
       </ol>
-      <daterangepicker :from="from" :to="to" v-on:update="onPickerUpdate"></daterangepicker>
+      <daterangepicker :from.sync="from" :to.sync="to" ref="daterangepicker"></daterangepicker>
     </div>
   </div>
 
@@ -95,11 +95,12 @@
     </div>
     <div class="card-body pt-0">
       <div :id="'legend' + key.key" class="legend-chart"><div class="row"><div class="col-md-4 col-md-offset-4"><div class="progress"><div class="progress-bar progress-bar-striped" style="width: 100%;">Loading, please wait ...</div></div></div></div></div>
-      <monitoring-chart check="{{check['name']}}" :key_="key.key" :value-type="key.value_type" :id="'chart' + key.key" :from="fromDate" :to="toDate"></monitoring-chart>
+      <monitoring-chart check="{{check['name']}}" :key_="key.key" :value-type="key.value_type" :id="'chart' + key.key" :from="from" :to="to"></monitoring-chart>
     </div>
   </div>
 </div>
 <script src="/js/vue.min.js"></script>
+<script src="/js/vue-router.min.js"></script>
 <script src="/js/dygraph.min.js"></script>
 <script src="/js/moment.min.js"></script>
 <script src="/js/daterangepicker.js"></script>


### PR DESCRIPTION
Changes in the daterangepicker have been done recently to allow users to choose how they want the date range to get refreshed. The alerting pages for showing a single metric got forgotten and didn't get updated accordingly.