### PR TITLE
Round to ceil value for end date

### DIFF
--- a/temboardui/plugins/monitoring/static/js/daterangepicker.vue.js
+++ b/temboardui/plugins/monitoring/static/js/daterangepicker.vue.js
@@ -230,6 +230,6 @@
 
   function notify() {
     this.$emit('update:from', dateMath.parse(this.editRawFrom));
-    this.$emit('update:to', dateMath.parse(this.editRawTo));
+    this.$emit('update:to', dateMath.parse(this.editRawTo, true));
   }
 })();


### PR DESCRIPTION
Fixes errors with ranges like 'yesterday' or 'last week' for which from
and to are equal in the range picker

Broken in 5579112