### PR TITLE
Make sure build directory is clean before building wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ upload:
 	@echo Checking we are on a tag
 	git describe --exact-match --tags
 	python2 -c 'import temboardui.toolkit'
+	@echo Clean build and dist directory
+	rm -rf build
 	python2.7 setup.py sdist bdist_wheel
 	twine upload dist/temboard-$(VERSION).tar.gz dist/temboard-$(VERSION)-py2-none-any.whl
 


### PR DESCRIPTION
If `build` contains files that are not in the source anymore they are kept. This leads to errors with alembic revisions files being kept though they were removed in code source for example.