### PR TITLE
complement MANIFEST.in and add check-manifest checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
             git diff --check $(git merge-base origin/master $CIRCLE_SHA1)..$CIRCLE_SHA1
             flake8
             python2.7 setup.py --long-description | rst2html.py --verbose --halt=warning - >/dev/null
+            check-manifest
       - run:
           name: Python tests
           command: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
+include CHANGELOG.md
 include LICENSE
 include packaging/temboard.service
+include temboardui/toolkit/LICENSE
 graft temboardui/model/alembic
 graft temboardui/static
 graft temboardui/templates
@@ -17,3 +19,27 @@ graft temboardui/plugins/statements/static
 graft temboardui/plugins/statements/templates
 graft share
 global-exclude *.pyc
+
+prune .circleci
+prune .editorconfig
+prune .gitmodules
+prune CONTRIBUTING.md
+prune QUICKSTART.md
+prune alembic.ini
+prune docker
+prune docker-compose.yml
+prune docs
+prune Gruntfile.js
+prune Makefile
+prune mkdocs.yml
+prune package.json
+prune packaging/deb
+prune packaging/rpm
+prune requirements-ci.txt
+prune temboard.conf
+prune temboardui/toolkit/.circleci
+prune temboardui/toolkit/.flake8
+prune temboardui/toolkit/README.md
+prune temboardui/toolkit/requirement-ci.txt
+prune temboardui/toolkit/tests
+prune tests

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ upload:
 	python2 -c 'import temboardui.toolkit'
 	@echo Clean build and dist directory
 	rm -rf build
+	check-manifest
 	python2.7 setup.py sdist bdist_wheel
 	twine upload dist/temboard-$(VERSION).tar.gz dist/temboard-$(VERSION)-py2-none-any.whl
 

--- a/packaging/rpm/README.rst
+++ b/packaging/rpm/README.rst
@@ -29,6 +29,7 @@ script will try to download the sources from PyPI.
 
 ::
 
+   check-manifest
    python setup.py sdist
    VERSION=$(python setup.py --version) make -C packaging/rpm/ all push
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,4 @@
+check-manifest
 flake8
 pytest<4
 pytest-cov


### PR DESCRIPTION
In order to avoid packaging errors by producing sdist or wheels with invalid content, we add `check-manifest` runs in CI and makefiles. The `MANIFEST.in` content is updated in order to have a clean result.