### PR TITLE
Extension btree_gist is not required anymore

### DIFF
--- a/temboardui/model/alembic/versions/statements.sql
+++ b/temboardui/model/alembic/versions/statements.sql
@@ -1,8 +1,5 @@
 DROP SCHEMA IF EXISTS statements CASCADE;
 CREATE SCHEMA statements;
--- Extension to allow GIST indexes on columns that otherwise wouldn't be
--- possible
-CREATE EXTENSION btree_gist;
 SET search_path TO statements, public;
 
 


### PR DESCRIPTION
At the same prevents error with missing privileges to create extension