### PR TITLE
Set isolation_level to autocommit for worker engine

### DIFF
--- a/temboardui/model/__init__.py
+++ b/temboardui/model/__init__.py
@@ -71,7 +71,7 @@ def worker_engine(dbconf):
     """Create a new stand-alone SQLAlchemy engine to be instantiated in worker
     context.
     """
-    return create_engine(format_dsn(dbconf))
+    return create_engine(format_dsn(dbconf), isolation_level="AUTOCOMMIT")
 
 
 def check_schema(config):


### PR DESCRIPTION
This prevents transactions to be open and rollback'ed by SQLAlchemy
before executing any statements

In the postgresql logs, we have a lot of the following statement:
```
statement: ROLLBACK
statement: BEGIN
statement: select version()
statement: select current_schema()
statement: show transaction isolation level
statement: SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
statement: SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
statement: SELECT 'x' AS some_label
statement: show standard_conforming_strings
statement: ROLLBACK
statement: BEGIN
statement: SELECT agent_address, agent_port, agent_key FROM application.instances ORDER BY 1, 2
statement: ROLLBACK
```

See https://stackoverflow.com/a/33090052/6830091

After applying this commit the number rollbacks on the repository database drops.
![Capture d’écran du 2020-11-05 08-52-09](https://user-images.githubusercontent.com/319774/98213739-ce57d800-1f45-11eb-9a68-cf3675cb2f76.png)
