### PR TITLE
Use unicode in Python3 as COPY destination

### DIFF
--- a/temboardui/plugins/monitoring/chartdata.py
+++ b/temboardui/plugins/monitoring/chartdata.py
@@ -3,7 +3,7 @@ try:
     from StringIO import StringIO
 except Exception:
     # python3
-    from io import BytesIO as StringIO
+    from io import StringIO
 import datetime
 from psycopg2.extensions import AsIs
 


### PR DESCRIPTION
Fixes:

    Unhandled Error:
    Traceback (most recent call last):
      File "/home/bersace/src/dalibo/temboard/temboardui/web.py", line 241, in error_middleware
        return func(request, *args)
      File "/home/bersace/src/dalibo/temboard/temboardui/web.py", line 422, in user_instance_middleware
        return func(request, address, port, *args)
      File "/home/bersace/src/dalibo/temboard/temboardui/web.py", line 281, in instance_middleware
        return callable_(request, *args)
      File "/home/bersace/src/dalibo/temboard/temboardui/web.py", line 445, in user_middleware
        return func(request, *args)
      File "/home/bersace/src/dalibo/temboard/temboardui/plugins/monitoring/handlers/monitoring.py", line 165, in data_metric
        key=key,
      File "/home/bersace/src/dalibo/temboard/temboardui/plugins/monitoring/chartdata.py", line 889, in get_metric_data_csv
        output=data_pivot
      File "/home/bersace/src/dalibo/temboard/temboardui/plugins/monitoring/pivot.py", line 18, in pivot_timeserie
        for r in get_csv_data(fd):
      File "/home/bersace/src/dalibo/temboard/temboardui/plugins/monitoring/pivot.py", line 7, in get_csv_data
        for r in csv.DictReader(fd):
      File "/home/bersace/.cache/pyenv/versions/3.6.8/lib/python3.6/csv.py", line 111, in __next__
        self.fieldnames
      File "/home/bersace/.cache/pyenv/versions/3.6.8/lib/python3.6/csv.py", line 98, in fieldnames
        self._fieldnames = next(self.reader)
    _csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)
    Request failed: 500 iterator should return strings, not bytes (did you open the file in text mode?).

Since pyscopg2 2.4, unicode is properly handled.