### PR TITLE
CONFIGFILE in create_repository.sh

### DIFF
--- a/share/create_repository.sh
+++ b/share/create_repository.sh
@@ -5,6 +5,8 @@
 # auto_configure.sh calls this script for production and Makefile for
 # development.
 
+CONFIGFILE=${ETCDIR-/etc/temboard}/temboard.conf
+
 if [ -n "${DEBUG-}" ] ; then
 	set -x
 fi
@@ -48,8 +50,8 @@ fi
 
 unset PGUSER PGHOST PGDATABASE PGPASSWORD
 
-if ! "${runas[@]}" temboard-migratedb check ; then
-    "${runas[@]}" temboard-migratedb upgrade
+if ! "${runas[@]}" temboard-migratedb -c "${CONFIGFILE}" check ; then
+    "${runas[@]}" temboard-migratedb -c "${CONFIGFILE}" upgrade
     if [ -n "${DEV-}" ] ; then
         "${psql[@]}" -f "$SQLDIR/dev-fixture.sql"
     fi


### PR DESCRIPTION
Ajout explicite du chemin du fichier de configuration de temboard pour la commande `temboard-migratedb`.
Jusqu’à présent la commande `temboard-migratedb` appelée dans ce script lisait toujours le fichier de configuration par défaut, c.a.d `/etc/temboard/temboard.conf`, même avec une personnalisation d’ `${ETCDIR}` lors de l’appel d’`auto_configure.sh`.
Le comportement reste inchangé si le script `create_repository.sh` est appelé via le Makefile ou via `auto_configure.sh` avec ${ETCDIR} à /etc/temboard (le cas par défaut).