### PR TITLE
Fix locks errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ script to proceed.
 - temBoard agent auto_configure.sh conditionnaly enable statements plugins.
 - temBoard agent auto_configure.sh now generates a single configuration file.
 - Dropped temBoard agent HTTP endpoint /monitoring/probe/*.
+- temBoard server waits for locks in monitoring collect. Abort long collect
+  task. New parameter `[monitoring] collect_max_duration`.
 
 
 ## [7.11] - Unreleased

--- a/ui/temboardui/model/versions/002_monitoring.sql
+++ b/ui/temboardui/model/versions/002_monitoring.sql
@@ -1337,7 +1337,7 @@ BEGIN
   v_table_current := table_name || '_current';
   v_table_history := table_name || '_history';
   -- Lock _current table to prevent concurrent updates
-  EXECUTE 'LOCK TABLE ' || v_table_current || ' IN SHARE MODE NOWAIT';
+  EXECUTE 'LOCK TABLE ' || v_table_current || ' IN SHARE MODE';
   v_query := replace(query, '#history_table#', v_table_history);
   v_query := replace(v_query, '#current_table#', v_table_current);
   v_query := replace(v_query, '#record_type#', record_type);

--- a/ui/temboardui/model/versions/008_monitoring-archive-wait-lock.sql
+++ b/ui/temboardui/model/versions/008_monitoring-archive-wait-lock.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION archive_current_metrics(table_name TEXT, record_type TEXT, query TEXT) RETURNS TABLE(tblname TEXT, nb_rows INTEGER)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_table_current TEXT;
+  v_table_history TEXT;
+  v_query TEXT;
+  i INTEGER;
+BEGIN
+  v_table_current := table_name || '_current';
+  v_table_history := table_name || '_history';
+  -- Lock _current table to prevent concurrent updates
+  EXECUTE 'LOCK TABLE ' || v_table_current || ' IN SHARE MODE';
+  v_query := replace(query, '#history_table#', v_table_history);
+  v_query := replace(v_query, '#current_table#', v_table_current);
+  v_query := replace(v_query, '#record_type#', record_type);
+  -- Move data into _history table
+  EXECUTE v_query;
+  GET DIAGNOSTICS i = ROW_COUNT;
+  -- Truncate _current table
+  EXECUTE 'TRUNCATE '||v_table_current;
+  -- Return each history table name and the number of rows inserted
+  RETURN QUERY SELECT v_table_history, i;
+END;
+$$;

--- a/ui/temboardui/plugins/monitoring/__init__.py
+++ b/ui/temboardui/plugins/monitoring/__init__.py
@@ -515,6 +515,7 @@ def collector(app, address, port, key=None):
                 instance_id,
                 row['instances'][0]['available']
             )
+            worker_session.commit()
             logger.info("Insert collected metrics for %s.", agent_id)
             insert_metrics(
                 worker_session, host.host_id, instance_id, data, dict(
@@ -525,7 +526,6 @@ def collector(app, address, port, key=None):
                     ),
                 ),
             )
-            worker_session.commit()
 
         except DataError as e:
             # Wrong data type or corrupted data could lead to DataError. In


### PR DESCRIPTION
cf. #931 

With this patch:

- Every task wait for lock.
- Collector task abort if taking too long, to avoid task storm.