### PR TITLE
Add explicit error in auto_configure if user not in ssl_cert group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,10 @@ $
 The `tests/` directory contains a pytest project to tests UI and agent
 integration using Selenium.
 
+On Debian your UNIX user must be in the ssl-cert group to run the tests.
+Be careful, the tests will use the local installation of temboard if it exists
+instead of dev files. To run the tests locally it is better not to have temboard installed.
+
 Execute these tests right from your virtualenv, using pytest:
 
 ``` console

--- a/ui/share/auto_configure.sh
+++ b/ui/share/auto_configure.sh
@@ -163,7 +163,11 @@ if ! getent passwd "$SYSUSER" ; then
 fi
 
 if getent group ssl-cert &>/dev/null && ! getent group ssl-cert | grep -q "$SYSUSER"; then
-	adduser "$SYSUSER" ssl-cert
+	if command -v adduser &>/dev/null ; then
+		adduser "$SYSUSER" ssl-cert
+	else
+		fatal "$SYSUSER is not member of ssl-cert group and can't execute adduser. Make sure to add user in group before executing."
+	fi
 fi
 
 


### PR DESCRIPTION
We additionaly updated the contributing documentation to warn that
the user must be in the ssl_cert group and that the local install of
temboard will be used if it exists instead of the dev files.