### PR TITLE
agent: Don't send hostname to register

### DIFF
--- a/agent/temboardagent/cli/register.py
+++ b/agent/temboardagent/cli/register.py
@@ -147,11 +147,9 @@ class Register(SubCommand):
             response.raise_for_status()
 
             # POSTing new instance
-            logger.info(
-                "Registering instance/agent in %s ...", ui_url_raw)
+            logger.info("Registering instance/agent in %s ...", ui_url_raw)
             path = ui_url.path + '/json/register/instance'
             response = uiclient.post(path, {
-                'hostname': discover['system']['hostname'],
                 'agent_key': app.config.temboard['key'],
                 'agent_address': args.host,
                 'agent_port': str(app.config.temboard['port']),


### PR DESCRIPTION
Fixes:

    INFO:  register: Registering instance/agent in http://172.17.0.1:8888 ...
    DEBUG:  http: Requesting POST http://172.17.0.1:8888/json/register/instance.
    DEBUG:  http: Response from 172.17.0.1:8888 in 0.007s: 500 Internal Server Error.
    CRITICAL:  app: UI returned error: 500: factory() got an unexpected keyword argument 'hostname'