### PR TITLE
Set monitoring purge_after default value to 730

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Ensure you use consistent title format.
   with APT instead of pip.
 - Use auto_configure.sh in docker images. Images are now idempotent.
 - Limit activity view to 300 longest queries.
+- Monitoring purge_after default value is now set to 730 (2 years), it was empty
+  before (no limit).
 
 [dalibo/temboard]: https://hub.docker.com/repository/docker/dalibo/temboard
 [dalibo/temboard-agent]: https://hub.docker.com/repository/docker/dalibo/temboard-agent

--- a/docs/server_configure.md
+++ b/docs/server_configure.md
@@ -140,7 +140,7 @@ Parameters related to the monitoring plugin.
 
   - **purge_after**
   Set the amount of data to keep, expressed in days.
-  Default: *empty*
+  Default: 730
 
 
 ### `statements`

--- a/ui/share/auto_configure.sh
+++ b/ui/share/auto_configure.sh
@@ -136,7 +136,7 @@ generate_configuration() {
 	level = ${TEMBOARD_LOGGING_LEVEL-INFO}
 
 	[monitoring]
-	# purge_after = 365
+	# purge_after = 730
 
 	[statements]
 	# purge_after = 7

--- a/ui/temboardui/cli/app.py
+++ b/ui/temboardui/cli/app.py
@@ -426,7 +426,7 @@ def list_options_specs():
     yield OptionSpec(s, 'twilio_from', default=None)
 
     s = 'monitoring'
-    yield OptionSpec(s, 'purge_after', default=None, validator=v.nday)
+    yield OptionSpec(s, 'purge_after', default=730, validator=v.nday)
 
     s = 'statements'
     yield OptionSpec(s, 'purge_after', default=7, validator=v.nday)


### PR DESCRIPTION
Before change we keep monitorings data indefinitely if purge_after was not defined. It's now set to two years (730 days) by default.