### PR TITLE
Force sqlalchemy version < 2

### DIFF
--- a/agent/temboardagent/web/app.py
+++ b/agent/temboardagent/web/app.py
@@ -10,14 +10,17 @@ from bottle import (
     default_app, request, response,
 )
 
-from ..toolkit.utils import JSONEncoder, utcnow
 from ..toolkit.http import format_date
-from ..toolkit.signing import (
-    InvalidSignature,
-    canonicalize_request,
-    verify_v1,
-)
+from ..toolkit.signing import InvalidSignature, canonicalize_request, verify_v1
+from ..toolkit.utils import JSONEncoder, utcnow
 
+# getfullargspec does not exist in python <= 2.7
+# getargspec no longer exist in python 3.11
+getargspec = (
+    inspect.getfullargspec
+    if not hasattr(inspect, "getargspec")
+    else inspect.getargspec
+)
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +106,7 @@ class PostgresPlugin(object):
         return wrapper
 
     def wants_postgres(self, callback):
-        argspec = inspect.getargspec(callback)
+        argspec = getargspec(callback)
         return [a for a in argspec.args if a in ('pgconn', 'pgpool')]
 
 

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -13,5 +13,5 @@ wheel
 # For integration tests
 httpx; python_version >= '3.6'
 selenium; python_version >= '3.6'
-sh; python_version >= '3.6'
+sh<2; python_version >= '3.6'
 tenacity; python_version >= '3.6'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,16 +33,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='session', autouse=True)
-def activate_virtualenv():
-    """Automatically activate temBoard UI virtualenv on debian."""
-
-    bindir = Path('/usr/lib/temboard/bin/')
-    if bindir.exists():
-        logger.debug("Activating %s virtualenv.", bindir.parent)
-        os.environ['PATH'] = f"{bindir}:{os.environ['PATH']}"
-
-
-@pytest.fixture(scope='session', autouse=True)
 def env():
     """
     Configure environment with superuser privileges.

--- a/tests/test_00_setup_ui.py
+++ b/tests/test_00_setup_ui.py
@@ -17,13 +17,19 @@ def test_setproctitle_script():
 def test_setproctitle_inline():
     from sh import python3
 
-    python3(c='import temboardui.toolkit.proctitle as pc; pc.test_main()')
+    python3(
+        c='import temboardui.toolkit.proctitle as pc; pc.test_main()',
+        _env={"PYTHONPATH": "/usr/lib/temboard"}
+    )
 
 
 def test_setproctitle_module():
     from sh import python3
 
-    python3(m='temboardui.toolkit.proctitle')
+    python3(
+        m='temboardui.toolkit.proctitle',
+        _env={"PYTHONPATH": "/usr/lib/temboard"}
+    )
 
 
 def test_temboard_version():

--- a/tests/test_30_dashboard.py
+++ b/tests/test_30_dashboard.py
@@ -19,7 +19,7 @@ def test_dashboard(browser, registered_agent, ui_url):
     sleep(.1)
     tooltip = browser.select("#cpu-info").get_attribute("aria-describedby")
     cpuinfo = browser.select(f"#{tooltip}").text
-    assert 'CPU @' in cpuinfo
+    assert 'GHz' in cpuinfo
 
     # Vanish tooltip
     browser.hover("body")

--- a/ui/packaging/rpm/temboard.spec
+++ b/ui/packaging/rpm/temboard.spec
@@ -30,11 +30,11 @@ Requires:      python3-tornado
 %if 0%{?rhel} < 8
 Requires:      python36-cryptography
 Requires:      python36-dateutil
-Requires:      python36-sqlalchemy
+Requires:      python36-sqlalchemy < 2
 %else
 Requires:      python3-cryptography
 Requires:      python3-dateutil >= 1.5
-Requires:      python3-sqlalchemy >= 0.9.8
+Requires:      python3-sqlalchemy >= 0.9.8, python3-sqlalchemy < 2
 %endif
 
 %description

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     # and there is no way to state an OR dependency in Python. It's up to
     # the user or package manager to ensure psycopg2 dependency. See
     # documentation.
-    'sqlalchemy>=0.9.8',
+    'sqlalchemy>=0.9.8,<2',
     'tornado>=3.2,<' + BLEEDING_EDGE_TORNADO,
     'future',
 ]


### PR DESCRIPTION
SQLAlchemy 2 introduces some changes that are no longer compatible with the current temBoard version.