### PR TITLE
Fix psycopg2 installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
               apt-get install -q -y --no-install-recommends python3-cffi
           fi
 
-          pip<< parameters.pyversion >> install --upgrade --editable ui/ --requirement dev/requirements.txt psycopg2-binary
+          pip<< parameters.pyversion >> install --upgrade --editable ui/ --requirement dev/requirements.txt --only-binary=psycopg2-binary psycopg2-binary
     - run:
         name: Install Agent.
         command: |
@@ -253,7 +253,7 @@ jobs:
               echo "Skipping agent for 2.7."
               exit
           fi
-          pip<< parameters.pyversion >> install --upgrade --editable agent/ psycopg2-binary
+          pip<< parameters.pyversion >> install --upgrade --editable agent/ --only-binary=psycopg2-binary psycopg2-binary
     - run:
         name: Agent Unit Tests
         command: |


### PR DESCRIPTION
We add --only-binary option to fix building error: ./psycopg/psycopg.h:36:22: fatal error: libpq-fe.h: No such file or directory