### PR TITLE
Fix wrong name for codecov package in dev/requirements

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,5 +1,4 @@
 check-manifest
-codecov
 flake8
 pytest
 pytest-cov


### PR DESCRIPTION
Fixes the following issue when running `make install-3.6`: ERROR: No matching distribution found for codecov