### PR TITLE
Improve error handling in agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Ensure you use consistent title format.
 - Internalize deps without virtualenv on UI debian package.
 - No longer displays UNDEF items in the UI
 - Fix logging on light terminal.
+- Improve errors displayed in the agent log
 
 
 ## 8.0

--- a/agent/temboardagent/web/core.py
+++ b/agent/temboardagent/web/core.py
@@ -1,6 +1,8 @@
 import logging
 
-from bottle import default_app, get, post, request, response
+from bottle import (
+    default_app, get, post, request, response, HTTPError, HTTPResponse
+)
 
 from ..notification import NotificationMgmt
 from ..toolkit.signing import canonicalize_request, verify_v1, InvalidSignature
@@ -8,6 +10,16 @@ from ..version import __version__ as version
 
 
 logger = logging.getLogger(__name__)
+
+
+@get('/error/<error_code:int>', skip=['signature'])
+def get_error(error_code):
+    if error_code < 400:
+        raise HTTPResponse('HTTPResponse raised', error_code)
+    elif error_code < 500:
+        raise HTTPError(error_code, 'HTTPError raised')
+    else:
+        raise Exception("This is an Exception %s" % error_code)
 
 
 @get('/discover', skip=['signature'])


### PR DESCRIPTION
Error raised when applying plugin where not shown in log and even when a 500 error, 200 where shown.
We avoid using after request hooks and add log in wsgi() surcharge. We removed ErrorPlugin to handle errors in default_error_handler().