### PR TITLE
Pin python minor version on debian

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
           command: |
             set -x
             # See https://discuss.circleci.com/t/commit-range-environment-variable/10410
-            git diff --check $(git merge-base origin/master $CIRCLE_SHA1)..$CIRCLE_SHA1
+            git --no-pager diff --check $(git merge-base origin/master $CIRCLE_SHA1)..$CIRCLE_SHA1
             flake8 tests/
             cd ui/
             flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Ensure you use consistent title format.
 - Improve errors displayed in the agent log
 - Remove stretch from packages and CI
 - Fix monitoring probe when the OS release includes a + sign.
+- Pin minor version of Python dependency in debian packages.
 
 
 ## 8.0

--- a/agent/packaging/deb/mkdeb.sh
+++ b/agent/packaging/deb/mkdeb.sh
@@ -66,6 +66,11 @@ rm -vf $(find "$DESTDIR/usr/lib" -name "*cpython-*.pyc" | grep -v "cpython-${pyt
 
 #       B U I L D
 
+PYTHON="$(readlink -e "$(type -p python3)")"
+python_pkg="$(dpkg -S "$PYTHON")"
+python_pkg="${python_pkg%:*}"
+python_pkg="${python_pkg/-minimal}"
+
 fpm --verbose \
     --force \
     --debug-workspace \
@@ -81,7 +86,7 @@ fpm --verbose \
     --maintainer "${DEBFULLNAME} <${DEBEMAIL}>" \
     --license PostgreSQL \
     --url https://labs.dalibo.com/temboard/ \
-    --depends python3 \
+    --depends "$python_pkg" \
     --depends python3-bottle \
     --depends python3-cryptography \
     --depends python3-pkg-resources \

--- a/ui/packaging/deb/mkdeb.sh
+++ b/ui/packaging/deb/mkdeb.sh
@@ -29,7 +29,7 @@ mkdir -p "$DESTDIR"
 
 #       V E R S I O N S
 
-PYTHON="$(type -p python3)"
+PYTHON="$(readlink -e "$(type -p python3)")"
 if [ -z "${VERSION-}" ] ; then
 	VERSION=$("$PYTHON" setup.py --version)
 fi


### PR DESCRIPTION
This prevent installing temBoard UI with bad Python version:

``` console
root@9bb6cceacdff:/etabli# grep 22 /etc/os-release
PRETTY_NAME="Ubuntu 22.04.1 LTS"
VERSION_ID="22.04"
VERSION="22.04.1 LTS (Jammy Jellyfish)"
root@9bb6cceacdff:/etabli# apt install ./temboard_8.1~dev0-0dlb1bullseye1_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'temboard' instead of './temboard_8.1~dev0-0dlb1bullseye1_amd64.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 temboard : Depends: python3.9 but it is not installable
E: Unable to correct problems, you have held broken packages.
root@9bb6cceacdff:/etabli#
```