### PR TITLE
Recover connection lost in statements and maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Ensure you use consistent title format.
 - Remove stretch from packages and CI
 - Fix monitoring probe when the OS release includes a + sign.
 - Pin minor version of Python dependency in debian packages.
+- Auto reconnect PostgreSQL on connection lost in statements and maintenance
+  agent endpoints.
 
 
 ## 8.0

--- a/agent/temboardagent/plugins/dashboard/__init__.py
+++ b/agent/temboardagent/plugins/dashboard/__init__.py
@@ -122,7 +122,7 @@ def dashboard_collector_batch_worker(app):
             logger.error("Failed to connect to Postgres: %s", e)
         else:
             try:
-                for attempt in pool.retry_connection():
+                for attempt in pool.auto_reconnect():
                     with attempt:
                         dashboard_collector_worker(app, pool)
             except Exception as e:

--- a/agent/temboardagent/plugins/dashboard/metrics.py
+++ b/agent/temboardagent/plugins/dashboard/metrics.py
@@ -12,7 +12,7 @@ def get_metrics(app, pool=None):
     res = dict()
     pool = pool or app.postgres.pool()
     discover = app.discover.ensure_latest()
-    for attempt in pool.retry_connection():
+    for attempt in pool.auto_reconnect():
         with attempt() as conn:
             dm = DashboardMetrics(conn)
             pgdiscover = discover['postgres']

--- a/agent/temboardagent/plugins/statements/__init__.py
+++ b/agent/temboardagent/plugins/statements/__init__.py
@@ -30,8 +30,9 @@ def get_statements(pgpool):
     dbname = config.statements.dbname
     snapshot_datetime = now()
     try:
-        conn = pgpool.getconn(dbname)
-        data = list(conn.query(query))
+        for connect in pgpool.auto_reconnect():
+            with connect(dbname) as conn:
+                data = list(conn.query(query))
     except Exception as e:
         discover = app.discover.ensure_latest()
         pg_version = discover['postgres']['version_num']

--- a/agent/temboardagent/web/app.py
+++ b/agent/temboardagent/web/app.py
@@ -114,7 +114,7 @@ class PostgresPlugin(object):
                 kw['pgpool'] = self.dbpool
 
             # Assume callbacks idempotence.
-            for attempt in self.pool.retry_connection():
+            for attempt in self.pool.auto_reconnect():
                 with attempt() as conn:
                     if 'pgconn' in wanted:
                         kw['pgconn'] = conn


### PR DESCRIPTION
Closes: #1231 

Steps to reproduce:

- start agent
- temboard query-agent https://0.0.0.0:2345/statements/
- *in monitored Postgres*: kill agent backends with `select pg_terminate_backend(pid) from pg_stat_activity where application_name = 'temboard-agent';`
- Requery: temboard query-agent https://0.0.0.0:2345/statements/

master returns a 500. With this PR, the connection lost is recovered.

```
2023-06-29 07:12:27 UTC temboardagent[551] DEBUG:  app: New web request: GET /statements/
2023-06-29 07:12:27 UTC temboardagent[551] DEBUG:  postgres: Retrying lost connection: server closed the connection unexpectedly
                This probably means the server terminated abnormally
                before or while processing the request.

2023-06-29 07:12:27 UTC temboardagent[551] DEBUG:  postgres: Closing pooled connection to postgres.
2023-06-29 07:12:27 UTC temboardagent[551] DEBUG:  postgres: Opening connection to db postgres.
2023-06-29 07:12:27 UTC temboardagent[551] INFO:  app: GET /statements/ 200 OK
172.26.0.1 - - [29/Jun/2023 07:12:27] "GET /statements/ HTTP/1.1" 200 76741
```