### PR TITLE
ui: Fix restart of temBoard on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Ensure you use consistent title format.
 - Unquote PGDATA from CSV inventory.
 - Fix missing schema in upgrade script.
 - Debian package now use system psycopg2.
+- Fix restart of temBoard when upgrading package.
 - Add user-agent in about page.
 - Internalize deps without virtualenv on debian package.
 - No longer displays UNDEF items.

--- a/ui/packaging/deb/postinst.sh
+++ b/ui/packaging/deb/postinst.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
 
-if systemctl daemon-reload &>/dev/null ; then
-	systemctl restart --state=ACTIVE temboard
+if systemctl is-active temboard &>/dev/null ; then
+	systemctl restart temboard
 fi


### PR DESCRIPTION
Fixes:

    Failed to restart temboard.service: Unit temboard.service not found.