### PR TITLE
Patch test config file entrypoint.sh ui

### DIFF
--- a/ui/packaging/docker/entrypoint.sh
+++ b/ui/packaging/docker/entrypoint.sh
@@ -7,7 +7,7 @@ PGPASSWORD=${PGPASSWORD-}
 export PGDATABASE=${PGDATABASE-$PGUSER}
 
 wait-for-it "${PGHOST}:${PGPORT}"
-if ! -f /etc/temboard/temboard.conf ; then
+if [ ! -f /etc/temboard/temboard.conf ] ; then
 	if ! DEBUG=y PGPASSWORD="$PGPASSWORD" /usr/share/temboard/auto_configure.sh; then
 		cat /var/log/temboard-auto-configure.log >&2
 		exit 1


### PR DESCRIPTION
Hello,

A small correction.
This was happening when the container was restarted: 

```bash
/usr/local/bin/docker-entrypoint.sh: line 10: -f: command not found
```