### PR TITLE
Remove unrequired Vue object in activity page

### DIFF
--- a/ui/temboardui/static/src/activity.js
+++ b/ui/temboardui/static/src/activity.js
@@ -1,6 +1,5 @@
 "use strict";
 
-import Vue from 'vue/dist/vue.esm'
 import datatables from 'datatables.net-dt'
 import dtbs4 from 'datatables.net-bs4'
 import 'datatables.net-bs4/css/dataTables.bootstrap4.css'
@@ -9,10 +8,6 @@ import 'highlight.js/styles/default.css'
 
 datatables(window, $)
 dtbs4(window, $)
-
-window.activityVue = new Vue({
-  el: "#activityVue"
-})
 
 var request = null;
 var intervalDuration = 2;


### PR DESCRIPTION
This is follow up for 6c211eb32537b3151a5d. After this commit, the Vue instance is not required anymore, we remove it.