### PR TITLE
Fix fontawesome files in 404 in dev mode

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -6,6 +6,10 @@ export default defineConfig({
   plugins: [vue()],
   root: "temboardui/static/src",
   base: "/static/",
+  server: {
+    origin: "http://localhost:5173",
+    port: 5173,
+  },
   build: {
     manifest: true,
     outDir: "..",


### PR DESCRIPTION
After spending some trying to fix the broken links to web font files for fontawesome, here's the only solution I found.

Should be merged after #1271