### PR TITLE
Don't sanitize content of bootstrap popover/tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Ensure you use consistent title format.
 - The `activity/running|blocking|waiting` endpoints don't exist anymore, only
   `activity` is available now.
 - Accept temboard-agent-register from v7 agent
+- Fix content for popover content in /pgconf/configuration page
 
 **Agent changes**
 

--- a/ui/temboardui/static/src/temboard.js
+++ b/ui/temboardui/static/src/temboard.js
@@ -55,6 +55,6 @@ $(() => {
   });
 
   // Popover and tooltip initialization
-  $('[data-toggle="popover"]').popover();
-  $('[data-toggle="tooltip"]').tooltip();
+  $('[data-toggle="popover"]').popover({ sanitize: false });
+  $('[data-toggle="tooltip"]').tooltip({ sanitize: false });
 });


### PR DESCRIPTION
This allows the usage of HTML tables in popover (for example in the /pgconf/configuration page). This is most probably broken since the change from bootstrap 3.x to 4.x in 977d828d5793d08ec635631fe.