### PR TITLE
agent: Add docker binary to base image

### DIFF
--- a/agent/packaging/docker/Dockerfile
+++ b/agent/packaging/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     apt-get update -y ; \
     mkdir -p /usr/share/man/man1 /usr/share/man/man7 ; \
     apt-get install -y --no-install-recommends \
+        docker.io \
         openssl \
         postgresql-client \
         ssl-cert \

--- a/agent/packaging/docker/Dockerfile.dev
+++ b/agent/packaging/docker/Dockerfile.dev
@@ -4,7 +4,6 @@ RUN set -ex; \
     apt-get update -y ; \
     mkdir -p /usr/share/man/man1 /usr/share/man/man7 ; \
     apt-get install -y --no-install-recommends \
-        docker.io \
         iproute2 \
         python3-pip \
         python3-hupper \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,7 +64,6 @@ services:
     volumes:
     - data15:/var/lib/postgresql/data
     - run15:/var/run/postgresql/
-    - /usr/bin/docker:/usr/bin/docker
     - /var/run/docker.sock:/var/run/docker.sock
     links:
     - instance15:instance15.acme.tld
@@ -100,7 +99,6 @@ services:
     volumes:
       - data13:/var/lib/postgresql/data
       - run13:/var/run/postgresql/
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - instance13:instance13.acme.tld
@@ -132,7 +130,6 @@ services:
     volumes:
       - data11:/var/lib/postgresql/data
       - run11:/var/run/postgresql/
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - instance11:instance11.acme.tld
@@ -164,7 +161,6 @@ services:
     volumes:
       - data96:/var/lib/postgresql/data
       - run96:/var/run/postgresql/
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - instance96:instance96.acme.tld


### PR DESCRIPTION
This make quickstart more portable.