### PR TITLE
Doc: Debian install: apt-key deprecated

### DIFF
--- a/docs/agent_install.md
+++ b/docs/agent_install.md
@@ -69,7 +69,7 @@ In order to run temBoard agent, you need:
 
     ``` console
     # echo deb http://apt.dalibo.org/labs $(lsb_release -cs)-dalibo main > /etc/apt/sources.list.d/dalibo-labs.list
-    # curl https://apt.dalibo.org/labs/debian-dalibo.asc | apt-key add -
+    # curl -fsSL -o /etc/apt/trusted.gpg.d/dalibo-labs.gpg https://apt.dalibo.org/labs/debian-dalibo.gpg
     # apt update  # You may use apt-get here.
     ```
 

--- a/docs/server_install.md
+++ b/docs/server_install.md
@@ -101,7 +101,7 @@ proper parameters, once temBoard package is installed.
 
     ``` console
     # echo deb http://apt.dalibo.org/labs $(lsb_release -cs)-dalibo main > /etc/apt/sources.list.d/dalibo-labs.list
-    # curl https://apt.dalibo.org/labs/debian-dalibo.asc | apt-key add -
+    # curl -fsSL -o /etc/apt/trusted.gpg.d/dalibo-labs.gpg https://apt.dalibo.org/labs/debian-dalibo.gpg
     # apt update
     ```
 


### PR DESCRIPTION
Update Debian install doc with the commands from http://apt.dalibo.org/labs/