### PR TITLE
Convert Home page to Vue SFC

### DIFF
--- a/ui/temboardui/static/src/components/home/InstanceList.vue
+++ b/ui/temboardui/static/src/components/home/InstanceList.vue
@@ -17,7 +17,7 @@ const loading = ref(false);
 const instances = ref([]);
 const search = ref(route.query.q);
 const sort = ref(route.query.sort || "status");
-const groups = ref([]);
+const groups = ref(window.groups || []);
 const groupsFilter = ref(route.query.groups ? route.query.groups.split(",") : []);
 const start = ref(moment().subtract(1, "hours"));
 const end = ref(moment());
@@ -50,8 +50,8 @@ const filteredInstances = computed(() => {
     if (!groupsFilter.value.length) {
       return true;
     }
-    return groupsFilter.value.every((group) => {
-      return instance.groups.indexOf(group) != -1;
+    return instance.groups.every((group) => {
+      return groupsFilter.value.indexOf(group) != -1;
     });
   });
 });
@@ -154,7 +154,7 @@ watch(sort, (newVal) => {
     query: _.assign({}, route.query, { sort: newVal }),
   });
 });
-watch(groupsFilter, (newVal) => {
+watch(groupsFilter.value, (newVal) => {
   router.replace({
     query: _.assign({}, route.query, { groups: newVal.join(",") }),
   });

--- a/ui/temboardui/static/src/components/home/InstanceList.vue
+++ b/ui/temboardui/static/src/components/home/InstanceList.vue
@@ -5,8 +5,9 @@ import moment from "moment";
 
 import InstanceCard from "./InstanceCard.vue";
 
+import { useFullscreen } from "@vueuse/core";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
-import { useRouter, useRoute } from "vue-router/composables";
+import { useRoute, useRouter } from "vue-router/composables";
 
 const root = ref(null);
 const instanceCards = ref(null);
@@ -17,16 +18,15 @@ const loading = ref(false);
 const instances = ref([]);
 const search = ref(route.query.q);
 const sort = ref(route.query.sort || "status");
-const groups = ref(window.groups || []);
 const groupsFilter = ref(route.query.groups ? route.query.groups.split(",") : []);
 const start = ref(moment().subtract(1, "hours"));
 const end = ref(moment());
 const refreshDate = ref(null);
 const refreshInterval = ref(3 * 1000);
 
-defineProps([
-  "isAdmin", // Whether connection user is Admin.
-]);
+const { toggle } = useFullscreen(root);
+
+const props = defineProps(["isAdmin", "groups"]);
 
 const filteredInstances = computed(() => {
   const searchRegex = new RegExp(search.value, "i");
@@ -163,6 +163,11 @@ watch(groupsFilter.value, (newVal) => {
 
 <template>
   <div ref="root">
+    <div class="position-absolute" style="z-index: 2; right: 0">
+      <button id="fullscreen" class="btn btn-link" @click="toggle">
+        <i class="fa fa-expand"></i>
+      </button>
+    </div>
     <div class="row">
       <div class="col mb-2">
         <form class="form-inline" onsubmit="event.preventDefault();">

--- a/ui/temboardui/static/src/home.js
+++ b/ui/temboardui/static/src/home.js
@@ -2,7 +2,7 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
 
-import InstanceList from "./components/home/InstanceList.vue";
+import Home from "./views/Home.vue";
 
 Vue.use(VueRouter);
 
@@ -10,6 +10,6 @@ new Vue({
   el: "#app",
   router: new VueRouter(),
   components: {
-    "instance-list": InstanceList,
+    home: Home,
   },
 });

--- a/ui/temboardui/static/src/home.js
+++ b/ui/temboardui/static/src/home.js
@@ -2,40 +2,14 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
 
-import "./fscreen.js";
 import InstanceList from "./components/home/InstanceList.vue";
 
 Vue.use(VueRouter);
 
-window.instancesVue = new Vue({
-  el: "#instances",
-  data: function () {
-    return {
-      currentRole,
-    };
-  },
+new Vue({
+  el: "#app",
   router: new VueRouter(),
   components: {
     "instance-list": InstanceList,
   },
-  template: `
-  <instance-list v-bind:isAdmin="currentRole.isAdmin">
-  </instance-list>
-  `,
 });
-
-$(".fullscreen").on("click", function (e) {
-  e.preventDefault();
-  $(this).addClass("d-none");
-  const el = $(this).parents(".container-fluid")[0];
-  fscreen.requestFullscreen(el);
-});
-
-fscreen.onfullscreenchange = function onFullScreenChange(event) {
-  if (!fscreen.fullscreenElement) {
-    $(".fullscreen").removeClass("d-none");
-  }
-};
-
-// hide fullscreen button if not supported
-$(".fullscreen").toggleClass("d-none", !fscreen.fullscreenEnabled);

--- a/ui/temboardui/static/src/views/Home.vue
+++ b/ui/temboardui/static/src/views/Home.vue
@@ -3,7 +3,7 @@
 import _ from "lodash";
 import moment from "moment";
 
-import InstanceCard from "./InstanceCard.vue";
+import InstanceCard from "../components/home/InstanceCard.vue";
 
 import { useFullscreen } from "@vueuse/core";
 import { computed, nextTick, onMounted, ref, watch } from "vue";

--- a/ui/temboardui/templates/base.html
+++ b/ui/temboardui/templates/base.html
@@ -17,17 +17,6 @@
   {% block head %}{# Put link and meta in head block to inject here #}{% end %}
 </head>
 <body>
-  <script type="text/javascript">
-    var currentRole = {
-      {% try %}
-      name: "{{ role.role_name }}",
-      isAdmin: {{ 'true' if role.is_admin else 'false' }}
-      {% except %}
-      name: null,
-      isAdmin: false
-      {% end %}
-    }
-  </script>
   <div>
     <script type="module" src="{{ vitejs.url_for('temboard.js') }}"></script>
     <script src="/js/jquery-2.1.4.min.js"></script>

--- a/ui/temboardui/templates/home.html
+++ b/ui/temboardui/templates/home.html
@@ -9,10 +9,10 @@
 {% block content %}
 {% import json %}
 <div id="app">
-  <instance-list
+  <home
     :is-admin="{{ 'true' if role.is_admin else 'false' }}"
     :groups='{% raw json.dumps([i[0] for i in groups]) %}'>
-  </instance-list>
+  </home>
 </div>
 <script type="module" src="{{ vitejs.url_for('home.js') }}"></script>
 {% end %}

--- a/ui/temboardui/templates/home.html
+++ b/ui/temboardui/templates/home.html
@@ -8,15 +8,11 @@
 
 {% block content %}
 {% import json %}
-<script>
-var groups = {% raw json.dumps([i[0] for i in groups]) %};
-</script>
+<div id="app">
+  <instance-list
+    :is-admin="{{ 'true' if role.is_admin else 'false' }}"
+    :groups='{% raw json.dumps([i[0] for i in groups]) %}'>
+  </instance-list>
+</div>
 <script type="module" src="{{ vitejs.url_for('home.js') }}"></script>
-<div class="position-absolute" style="z-index: 2; right: 0;">
-  <a class="btn btn-link fullscreen" href data-toggle="popover" data-trigger="hover" data-content="Full screen" data-placement="bottom">
-    <i class="fa fa-expand"></i>
-  </a>
-</div>
-<div id="instances">
-</div>
 {% end %}


### PR DESCRIPTION
currentRole has been removed from base.html, it was only used in home.html.
isAdmin and groups are now passed as props to the InstanceList component.
The groups filter has been fixed.

In the second commit, the `InstanceList` component has been renamed and moved to `Home` view.