### PR TITLE
Fix missing import (dateMath) in rangeutils

### DIFF
--- a/ui/temboardui/static/src/rangeutils.js
+++ b/ui/temboardui/static/src/rangeutils.js
@@ -1,13 +1,12 @@
-/* global define, moment, _, dateMath */
-
 /*
  * This is a port of the excellent grafana's RangeUtils utils package.
  * From TypeScript to pure Javascript.
  * See https://github.com/grafana/grafana/blob/master/public/app/core/utils/rangeutils.ts
- *
- * Requires `dateMath`, `moment` and `loadash`.
  */
 import * as _ from "lodash";
+import moment from "moment";
+
+import dateMath from "./datemath.js";
 
 var spans = {
   s: { display: "second" },


### PR DESCRIPTION
The error happens when one of the dates in the rangepicker is not relative to now.