### PR TITLE
Make copy work even in 'not secure' mode

### DIFF
--- a/ui/temboardui/static/src/views/About.vue
+++ b/ui/temboardui/static/src/views/About.vue
@@ -21,7 +21,7 @@ function getMetadata() {
           </div>
         </div>
         <div style="position: relative">
-          <UseClipboard v-slot="{ copy, copied }">
+          <UseClipboard v-slot="{ copy, copied }" :legacy="true">
             <button
               id="buttonCopy"
               class="btn btn-light"


### PR DESCRIPTION
Copy doesn't not work due to security limitations when using 0.0.0.0:8888 (built mode).

See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#concepts_and_usage.