### PR TITLE
Fix deprecation warning for highlight.js usage

### DIFF
--- a/ui/temboardui/static/src/views/Activity.vue
+++ b/ui/temboardui/static/src/views/Activity.vue
@@ -150,7 +150,7 @@ function doFilter(row) {
 }
 
 function highlight(src) {
-  return hljs.highlight("sql", src).value;
+  return hljs.highlight(src, { language: "sql" }).value;
 }
 
 function fields() {


### PR DESCRIPTION
The warning is the following one:
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated. Deprecated as of 10.7.0. Please use highlight(code, options) instead.