### PR TITLE
Fix path to rst2html binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           command: |
             cd agent/
             flake8 temboardagent
-            python setup.py --long-description | rst2html.py --verbose --halt=warning - >/dev/null
+            python setup.py --long-description | rst2html --verbose --halt=warning - >/dev/null
             check-manifest
       - run:
           name: Lint UI


### PR DESCRIPTION
There seem to have changed in the last version of docutils.