### PR TITLE
Pin minimum version of node in package-lock.json

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -34,6 +34,9 @@
         "prettier": "^3.3.2",
         "sass": "^1.77.6",
         "vite": "^5.3.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
This was forgotten in commit b8f3d0fd.