### PR TITLE
Empty outDir upon npm build

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
   build: {
     manifest: true,
     outDir: "../dist",
-    emptyOutDir: false,
+    emptyOutDir: true,
     assetsDir: ".",
     rollupOptions: {
       output: {


### PR DESCRIPTION
This avoid accumulation of built assets.
This was not possible before 258ee14e.