### PR TITLE
Make elements id unique in InstanceForm

### DIFF
--- a/tests/fixtures/ui.py
+++ b/tests/fixtures/ui.py
@@ -259,10 +259,10 @@ def registered_agent(admin_session, agent, agent_conf, browser_session, pg_versi
     port = agent_conf.get("temboard", "port")
     browser.select("input#inputAgentPort").send_keys(port)
     browser.select("#buttonDiscover").click()
-    browser.select("#selectGroups option").click()
-    browser.select("textarea#inputComment").send_keys("Registered by tests.")
+    browser.select("#selectGroupsNew option").click()
+    browser.select("textarea#inputCommentNew").send_keys("Registered by tests.")
 
-    browser.select("#buttonSubmit").click()
+    browser.select("#buttonSubmitNew").click()
     td = browser.select("td.agent span.hostport")
     assert f"0.0.0.0:{port}" in td.text
 

--- a/tests/test_20_inventory.py
+++ b/tests/test_20_inventory.py
@@ -48,14 +48,14 @@ def test_about_instance(registered_agent, agent_conf, browser, ui_url):
 def test_edit_instance(registered_agent, browser, ui_url):
     browser.get(ui_url + "/settings/instances")
     browser.select("td button.buttonEdit").click()
-    browser.select("#inputNotify").click()
-    comment = browser.select("#inputComment").get_attribute("value")
+    browser.select("#inputNotifyUpdate").click()
+    comment = browser.select("#inputCommentUpdate").get_attribute("value")
     assert "Registered by tests." == comment
     default_selected = browser.select(
-        "#selectGroups option[value='default']"
+        "#selectGroupsUpdate option[value='default']"
     ).get_attribute("selected")
     assert default_selected == "true"
-    browser.select("#buttonSubmit").click()
+    browser.select("#buttonSubmitUpdate").click()
 
 
 def test_download_inventory(registered_agent, browser):

--- a/ui/temboardui/static/src/components/settings/InstanceForm.vue
+++ b/ui/temboardui/static/src/components/settings/InstanceForm.vue
@@ -6,6 +6,7 @@ import InstanceDetails from "./InstanceDetails.vue";
 const props = defineProps([
   "submit_text", // Submit button label.
   "waiting", // Whether parent is interacting with server.
+  "type", // Either 'New' or 'Update'
 
   // Discover readonly data.
   "pg_host",
@@ -41,8 +42,8 @@ function submit() {
   // /json/settings/instances/X.X.X.X/PPPP.
   const data = {
     // Define parameters.
-    groups: $("#selectGroups").val(),
-    plugins: $("#selectPlugins").val(),
+    groups: $("#selectGroups" + props.type).val(),
+    plugins: $("#selectPlugins" + props.type).val(),
     notify: props.notify,
     comment: commentModel.value,
   };
@@ -75,8 +76,8 @@ const emit = defineEmits(["submit"]);
 
       <div class="row">
         <div id="divGroups" class="form-group col-sm-6" v-if="groups.length > 0">
-          <label for="selectGroups">Groups</label>
-          <select id="selectGroups" :disabled="waiting" multiple required>
+          <label :for="'selectGroups' + type">Groups</label>
+          <select :id="'selectGroups' + type" :disabled="waiting" multiple required>
             <option
               v-for="group of groups"
               :key="group.name"
@@ -89,8 +90,8 @@ const emit = defineEmits(["submit"]);
           <div id="tooltip-container"></div>
         </div>
         <div id="divPlugins" class="form-group col-sm-6" v-if="plugins.length > 0">
-          <label for="selectPlugins" class="control-label">Plugins</label>
-          <select id="selectPlugins" :disabled="waiting" multiple="multiple">
+          <label :for="'selectPlugins' + type" class="control-label">Plugins</label>
+          <select :id="'selectPlugins' + type" :disabled="waiting" multiple="multiple">
             <option
               v-for="plugin of plugins"
               :key="plugin.name"
@@ -108,22 +109,34 @@ const emit = defineEmits(["submit"]);
       <div class="row">
         <div class="col-sm-12">
           <div class="form-check">
-            <input id="inputNotify" class="form-check-input" type="checkbox" :value="notify" :disabled="waiting" />
-            <label for="inputNotify" class="control-label">Notify users of any status alert.</label>
+            <input
+              :id="'inputNotify' + type"
+              class="form-check-input"
+              type="checkbox"
+              :value="notify"
+              :disabled="waiting"
+            />
+            <label :for="'inputNotify' + type" class="control-label">Notify users of any status alert.</label>
           </div>
         </div>
       </div>
       <div class="row">
         <div class="form-group col-sm-12">
-          <label for="inputComment" class="control-label">Comment</label>
-          <textarea id="inputComment" class="form-control" rows="3" v-model="commentModel" :disabled="waiting">
+          <label :for="'inputComment' + type" class="control-label">Comment</label>
+          <textarea
+            :id="'inputComment' + type"
+            class="form-control"
+            rows="3"
+            v-model="commentModel"
+            :disabled="waiting"
+          >
           </textarea>
         </div>
       </div>
     </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cancel</button>
-      <button id="buttonSubmit" class="btn btn-success ml-auto" type="submit" :disabled="waiting">
+      <button :id="'buttonSubmit' + type" class="btn btn-success ml-auto" type="submit" :disabled="waiting">
         {{ submit_text }}
         <i v-if="waiting" class="fa fa-spinner fa-spin loader"></i>
       </button>

--- a/ui/temboardui/static/src/components/settings/NewInstanceWizard.vue
+++ b/ui/temboardui/static/src/components/settings/NewInstanceWizard.vue
@@ -199,6 +199,7 @@ function reset() {
       <InstanceForm
         ref="formCmp"
         submit_text="Register"
+        type="New"
         :pg_host="state.pg_host"
         :pg_port="state.pg_port"
         :pg_data="state.pg_data"

--- a/ui/temboardui/static/src/components/settings/UpdateInstanceDialog.vue
+++ b/ui/temboardui/static/src/components/settings/UpdateInstanceDialog.vue
@@ -176,6 +176,7 @@ defineExpose({ open });
     <InstanceForm
       ref="formCmp"
       submit_text="Update"
+      type="Update"
       :pg_host="form.pg_host"
       :pg_port="form.pg_port"
       :pg_data="form.pg_data"


### PR DESCRIPTION
InstanceForm is used in 2 different modals in the settings.instance page. Using the same id for form elements was leading to potential conflicts.