### PR TITLE
Readd bootstrap for configuration page

### DIFF
--- a/ui/temboardui/plugins/pgconf/templates/configuration.html
+++ b/ui/temboardui/plugins/pgconf/templates/configuration.html
@@ -5,6 +5,7 @@
 {% block head %}
 <link href="/css/pgconf/temboard.pgconf.css" rel="stylesheet">
 <script src="/js/jquery-2.1.4.min.js"></script>
+<script src="/js/bootstrap.min.js"></script>
 {% end %}
 
 {% block content %}


### PR DESCRIPTION
It has been removed in 999a9bf3d3965. But it is still required for the reset_default modal.