### PR TITLE
Improve flask error, 401, 403 and 404 templates

### DIFF
--- a/ui/temboardui/templates/flask/401.html
+++ b/ui/temboardui/templates/flask/401.html
@@ -3,14 +3,12 @@
 {% block title %}{{ super() }}/ Authentication required{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-4 col-md-offset-4">
+<div class="row justify-content-center">
+  <div class="col col-xl-6 col-10">
     <div class="alert alert-danger alert-restricted" role="alert">
-      <h4><i class="fa fa-ban fa-fw"></i> Error <small></small></h4>
-      <p>Authentication required</p>
-      <p>Go to <a class="btn btn-sm btn-danger" href="/login">login page</a> to authenticate.</p>
+      <h4><i class="fa fa-ban fa-fw"></i> Authentication required <small></small></h4>
+      <p>Go to <a href="/login">login page</a> to authenticate.</p>
     </div>
   </div>
-  <div class="col-md-4"></div>
 </div>
 {% endblock %}

--- a/ui/temboardui/templates/flask/403.html
+++ b/ui/temboardui/templates/flask/403.html
@@ -3,16 +3,14 @@
 {% block title %}{{ super() }}/ Restricted area{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-4 col-md-offset-4">
+<div class="row justify-content-center">
+  <div class="col col-xl-6 col-10">
     <div class="alert alert-danger alert-restricted" role="alert">
-      <h4><i class="fa fa-ban fa-fw"></i> Error <small></small></h4>
-      <p>Restricted area...</p>
+      <h4><i class="fa fa-ban fa-fw"></i> Restricted area <small></small></h4>
       <p>You are not allowed to access this page.<br/>
-      Go <a class="btn btn-sm btn-danger" href="/">back to home page</a>
+      Go <a href="/">back to home page</a>
       or ask your temBoard administrator to grant access to you.</p>
     </div>
   </div>
-  <div class="col-md-4"></div>
 </div>
 {% endblock %}

--- a/ui/temboardui/templates/flask/404.html
+++ b/ui/temboardui/templates/flask/404.html
@@ -3,9 +3,12 @@
 {% block title %}{{ super() }}/ Not Found{% endblock %}
 
 {% block content %}
-<div class="container text-center">
-  <h1>Oops!</h1>
-  <h2>404 - Page Not Found</h2>
-  <p>The page you are looking for might have been removed or had its name changed.</p>
+<div class="row justify-content-center">
+  <div class="col col-xl-6 col-10">
+    <div class="alert alert-danger alert-restricted" role="alert">
+      <h4><i class="fa fa-ban fa-fw"></i> Page not Found <small></small></h4>
+      <p>The page you are looking for might have been removed or had its name changed.</p>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/ui/temboardui/templates/flask/error.html
+++ b/ui/temboardui/templates/flask/error.html
@@ -1,10 +1,10 @@
-{% extends base.html %}
+{% extends "base.html" %}
 
 {% block title %}{{ super() }}/ Error{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-6 col-md-offset-3">
+<div class="row justify-content-center">
+  <div class="col col-xl-6 col-10">
     <div class="alert alert-danger" role="alert">
       <h4><i class="fa fa-ban fa-fw"></i> Error</h4>
       <p>{{error}}</p>


### PR DESCRIPTION
We add double quotes around the extended error
template file, this is a fix for the error template
that was not correctly displayed.
We also center all error pages and review the style.