### PR TITLE
ui: Make closed event is emitted when the modal in hidden

### DIFF
--- a/ui/temboardui/static/src/components/ModalDialog.vue
+++ b/ui/temboardui/static/src/components/ModalDialog.vue
@@ -7,7 +7,7 @@ defineProps(["id", "title"]);
 const emit = defineEmits(["closed"]);
 const root = ref(null);
 onMounted(() => {
-  $(root.value).on("hidden.bs.modal", () => {
+  root.value.addEventListener("hidden.bs.modal", () => {
     emit("closed");
   });
 });


### PR DESCRIPTION
BS5 doesn't rely on JQuery anymore.

This fixes an error with the Instance wizard not being reset after modal close.