### PR TITLE
Catch exception when loading user from cookie

### DIFF
--- a/ui/temboardui/web/flask.py
+++ b/ui/temboardui/web/flask.py
@@ -297,7 +297,10 @@ class UserMiddleware:
         )
         if cookie:
             cookie = cookie.decode("utf-8")
-            return get_role_by_cookie(g.db_session, cookie)
+            try:
+                return get_role_by_cookie(g.db_session, cookie)
+            except Exception as e:
+                logger.error("Failed to load user from cookie: %s", e)
 
 
 class InstanceMiddleware:


### PR DESCRIPTION
In case of a bad cookie, a 500 error was thrown.
This stuck the user until the cookie was manually
removed. It happens on password change of the
currently connected user.