### PR TITLE
Ensure from addr

### DIFF
--- a/ui/temboardui/application.py
+++ b/ui/temboardui/application.py
@@ -130,7 +130,7 @@ def send_mail(
             logger.debug("Authenticating to SMTP server as %s.", login)
             smtp.login(login, password)
 
-        smtp.sendmail(from_addr, emails, msg.as_string())
+        smtp.sendmail(from_addr or "temboard@undefined", emails, msg.as_string())
         smtp.quit()
     except Exception as e:
         raise TemboardUIError(


### PR DESCRIPTION
Fixes:

     temboardui.errors.TemboardUIError: Could not send mail; 'NoneType' object has no attribute 'strip'
     SMTP connection may be misconfigured.