### PR TITLE
Don't hide empty table headers

### DIFF
--- a/docs/assets/temboard.css
+++ b/docs/assets/temboard.css
@@ -43,7 +43,3 @@ div.injected {
   height: 2.4rem;
   line-height: 2.4rem;
 }
-
-th:empty {
-  display: none;
-}


### PR DESCRIPTION
By hiding table headers we may face issues with column headers not being aligned with the body cells.

This was introduced in 0c54fcf85170010 without explaining why.

Before:
![Screenshot from 2024-10-24 15-27-56](https://github.com/user-attachments/assets/591adc19-8bc7-44cd-a9f4-31219dd570eb)

After:
![Screenshot from 2024-10-24 15-27-30](https://github.com/user-attachments/assets/9eec1dad-9c4e-4456-9df9-0ba89bd3c06f)
