### PR TITLE
ui: Manage `cookie_timeout` in Temboard UI configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ You need manual steps when upgrading UI.
 - Requires Python 3.9.
 - Packages for Debian Trixie.
 - Packages for RHEL 10.
+- Add cookie_timeout to UI configuration.
 
 
 ## 9.0.0

--- a/docs/server_configure.md
+++ b/docs/server_configure.md
@@ -35,6 +35,11 @@ This is the main section grouping core parameters :
   Secret key used to crypt cookie content.
   Default: *empty*;
 
+  - **cookie_timeout**
+  Cookie timeout in second. Default is 1 day (84600). The cookie expiration is
+  updated whenever there is an activity.
+  Default: 84600;
+
   - **plugins**
   Array of plugin name to load.
   Default: `["monitoring", "dashboard", "pgconf", "activity", "maintenance",

--- a/ui/temboardui/cli/app.py
+++ b/ui/temboardui/cli/app.py
@@ -406,6 +406,7 @@ def list_options_specs():
         s, "signing_public_key", default="signing-public.pem", validator=v.path
     )
     yield OptionSpec(s, "cookie_secret", validator=cookie_secret)
+    yield OptionSpec(s, "cookie_timeout", default=84600, validator=int)
     home = os.environ.get("HOME", "/var/lib/temboard")
     yield OptionSpec(s, "home", default=home, validator=v.writeabledir)
 

--- a/ui/temboardui/web/flask.py
+++ b/ui/temboardui/web/flask.py
@@ -95,6 +95,20 @@ def create_app(temboard_app):
         resp.headers["Content-Security-Policy"] = csp
         return resp
 
+    @app.after_request
+    def refresh_cookie(resp):
+        if request.endpoint == "logout":
+            return resp
+        cookie = request.cookies.get("temboard")
+        if cookie:
+            resp.set_cookie(
+                "temboard",
+                cookie,
+                secure=True,
+                max_age=app.temboard.config.temboard.cookie_timeout,
+            )
+        return resp
+
     ViteJSExtension(app)
     # finalize_app() must be called before serving, to enable configured
     # blueprints.

--- a/ui/temboardui/web/routes/auth.py
+++ b/ui/temboardui/web/routes/auth.py
@@ -56,7 +56,12 @@ def json_login():
         "temboard",
         gen_cookie(role.role_name, passhash),
     )
-    response.set_cookie("temboard", secret_cookie.decode(), secure=True)
+    response.set_cookie(
+        "temboard",
+        secret_cookie.decode(),
+        secure=True,
+        max_age=app.temboard.config.temboard.cookie_timeout,
+    )
     return response
 
 


### PR DESCRIPTION
Set default to 86400, expiration is updated whenever there is activity.