### PR TITLE
dev: Use home instead of data in docker compose 

### DIFF
--- a/agent/packaging/docker/entrypoint.sh
+++ b/agent/packaging/docker/entrypoint.sh
@@ -3,8 +3,8 @@
 set -x
 
 # Create postgres user matching postgres container one.
-POSTGRES_UID=$(stat -c "%u" "$PGDATA")
-POSTGRES_GID=$(stat -c "%g" "$PGDATA")
+POSTGRES_UID=$(stat -c "%u" "/var/lib/postgresql")
+POSTGRES_GID=$(stat -c "%g" "/var/lib/postgresql")
 if ! getent passwd postgres &>/dev/null ; then
 	groupadd --system --gid "${POSTGRES_GID}" postgres
 	useradd --system \

--- a/dev/docker-compose.massagent.yml
+++ b/dev/docker-compose.massagent.yml
@@ -7,12 +7,12 @@ networks:
     external: true
 
 volumes:
-  data:
+  home:
   run:
 
 services:
   postgres:
-    image: postgres:${PGVERSION-17}-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_PASSWORD: confinment
     command: [
@@ -21,7 +21,7 @@ services:
       -c, "cluster_name=postgres-${TEMBOARD_REGISTER_PORT}",
     ]
     volumes:
-      - data:/var/lib/postgresql/data
+      - home:/var/lib/postgresql
       - run:/var/run/postgresql
       - type: bind
         source: ../ui/share/sql/pg_stat_statements-create-extension.sql
@@ -40,9 +40,8 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - data:/var/lib/postgresql/data
+      - home:/var/lib/postgresql
       - run:/var/run/postgresql
-      - /var/run/docker.sock:/var/run/docker.sock
     links:
       - "postgres:postgres-${TEMBOARD_REGISTER_PORT}.dev"
     environment:

--- a/dev/postgres-ha-entrypoint.sh
+++ b/dev/postgres-ha-entrypoint.sh
@@ -22,7 +22,6 @@ _ha_setup() {
     docker_setup_env
 
     chown postgres:postgres /var/lib/postgresql/archive
-    chown postgres:postgres "$PGDATA"
 
     echo "Waiting for $PEER_HOST to have network."
     if ! peerhost="$(_retry getent hosts "$PEER_HOST")"; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   postgres0:
     image: &postgres_image postgres:18-alpine
     volumes:
-    - data0:/var/lib/postgresql/18/docker
+    - home0:/var/lib/postgresql
     - run0:/var/run/postgresql
     - wal:/var/lib/postgresql/archive/
     - ./dev/postgres-ha-entrypoint.sh:/usr/local/bin/postgres-ha-entrypoint.sh
@@ -66,7 +66,7 @@ services:
       context: agent/
       dockerfile: packaging/docker/Dockerfile.dev
     volumes:
-    - data0:/var/lib/postgresql/18/docker
+    - home0:/var/lib/postgresql
     - run0:/var/run/postgresql
     - /var/run/docker.sock:/var/run/docker.sock
     - ./:/usr/local/src/temboard/
@@ -76,7 +76,6 @@ services:
       # container.
       HISTFILE: /usr/local/src/temboard/dev/agent-bash_history
       PGUSER: postgres
-      PGDATA: /var/lib/postgresql/18/docker
       PSQL_HISTORY: /usr/local/src/temboard/dev/agent-psql_history
       # Send TEMBOARD_UI_URL from .env file
       TEMBOARD_UI_URL: "${TEMBOARD_UI_URL-}"
@@ -96,7 +95,7 @@ services:
   postgres1:
     image: *postgres_image
     volumes:
-    - data1:/var/lib/postgresql/18/docker
+    - home1:/var/lib/postgresql
     - run1:/var/run/postgresql
     - wal:/var/lib/postgresql/archive/
     - ./dev/postgres-ha-entrypoint.sh:/usr/local/bin/postgres-ha-entrypoint.sh
@@ -126,7 +125,7 @@ services:
     build:
       <<: *build-agent
     volumes:
-    - data1:/var/lib/postgresql/18/docker
+    - home1:/var/lib/postgresql
     - run1:/var/run/postgresql
     - /var/run/docker.sock:/var/run/docker.sock
     - ./:/usr/local/src/temboard/
@@ -235,12 +234,12 @@ volumes:
   wal:
 
   # data_directory for first postgres instance.
-  data0:
+  home0:
   # /run/postgresql to share socket between postgres instance and agent.
   run0:
 
   # data directory for second postgres instances.
-  data1:
+  home1:
   # /run/postgresql to share socket between postgres instance and agent.
   run1:
 


### PR DESCRIPTION
The PostgreSQL data folder may not be created when mounting the container.
Using the home folder of the postgres user prevents group and user issues.
Mass-Agents runs on PostgreSQL 18.