### PR TITLE
Drop PyPI publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,16 +365,6 @@ jobs:
             --title "${CIRCLE_TAG#v}" \
             -F <(make -s release-notes VERSION=${CIRCLE_TAG#v}) \
             "${args[@]}"
-    - run:
-        name: Upload Agent to PyPI
-        command: |
-          set -u
-          UV_PUBLISH_TOKEN="$AGENT_PYPI_TOKEN" uv publish agent/dist/*.{tar.gz,whl}
-    - run:
-        name: Upload UI to PyPI
-        command: |
-          set -u
-          UV_PUBLISH_TOKEN="$UI_PYPI_TOKEN" uv publish ui/dist/*.{tar.gz,whl}
 
   docker:
     docker: [{image: dalibo/buildpack-pkg:trixie}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You need manual steps when upgrading UI.
 - Packages for Debian Trixie.
 - Packages for RHEL 10.
 - Add cookie_timeout to UI configuration.
+- Drop PyPI availability. Use APT/YUM repositories or GitHub releases.
 
 
 ## 9.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -426,8 +426,7 @@ This helps reading diff, handling conflicts when rebasing.
 Building packages for RHEL, Debian and compatible clones requires Docker and Docker Compose for isolation.
 UI and agent each have `packaging/nfpm/` directory with a Makefile and scripts to build DEB and RPM packages.
 
-The builder script searches for wheels in respective `dist/`
-and if not found, tries to download wheel from PyPI.
+The builder script searches for wheels in respective `dist/`.
 Use top level `make dist` to generate wheels.
 
 

--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,6 @@ clean-static:  #: Clean UI browser assets.
 	rm -vrf \
 		ui/temboardui/static/dist
 
-download-eggs:  #: Download Python eggs from PyPI
-	pip3 download --no-deps --dest agent/dist/ temboard-agent==$(VERSION)
-	pip3 download --no-deps --dest ui/dist/ temboard==$(VERSION)
-
 YUM_LABS?=../yum-labs
 CURL=curl --fail --create-dirs --location --silent --show-error
 GH_DOWNLOAD=https://github.com/dalibo/temboard/releases/download/v$(VERSION)

--- a/agent/packaging/nfpm/mkdeb.sh
+++ b/agent/packaging/nfpm/mkdeb.sh
@@ -37,13 +37,8 @@ RELEASE=0dlb1${codename}1
 
 #       I N S T A L L
 
-whl="dist/temboard_agent-$pep440v-py3-none-any.whl"
-if ! [ -f "$whl" ] ; then
-	pip3 download --only-binary :all: --no-deps --pre --dest "dist/" "temboard-agent==$pep440v"
-fi
-
 # Install from sources
-pip3 install --pre --root "$DESTDIR" --prefix /usr --no-deps "$whl"
+pip3 install --pre --root "$DESTDIR" --prefix /usr --no-deps "dist/temboard_agent-$pep440v-py3-none-any.whl"
 
 # Fake --install-layout=deb, when using wheel.
 pythonv=$(python3 --version |& grep -Po 'Python \K(3\.[0-9]{1,2})')

--- a/agent/packaging/nfpm/mkrpm.sh
+++ b/agent/packaging/nfpm/mkrpm.sh
@@ -38,13 +38,8 @@ RELEASE="1$(rpm --eval '%{dist}')"
 #       I N S T A L L
 
 
-whl="dist/temboard_agent-$VERSION-py3-none-any.whl"
-if ! [ -f "$whl" ] ; then
-	"${pip[@]}" download --only-binary :all: --no-deps --pre --dest "dist/" "temboard-agent==$VERSION"
-fi
-
 # Install from sources
-"${pip[@]}" install --pre --root "$DESTDIR" --prefix /usr --no-deps "$whl"
+"${pip[@]}" install --pre --root "$DESTDIR" --prefix /usr --no-deps "dist/temboard_agent-$VERSION-py3-none-any.whl"
 # Vendor dependencies.
 pythonv=$("$python" --version |& grep -Po 'Python \K(3\.[0-9]{1,2})')
 uv pip install \

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -8,15 +8,7 @@ license = "PostgreSQL"
 authors = [
     {name = "Dalibo", email = "contact@dalibo.com"},
 ]
-classifiers = [
-    "Environment :: No Input/Output (Daemon)",
-    "Intended Audience :: System Administrators",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Topic :: Database :: Database Engines/Servers",
-    "Topic :: System :: Monitoring",
-]
+classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "cryptography",
 ]

--- a/tests/fixtures/agent.py
+++ b/tests/fixtures/agent.py
@@ -172,8 +172,6 @@ def agent_sharedir():
     candidates = [
         # rpm/deb
         "/usr/share/temboard-agent",
-        # pip install
-        "/usr/local/share/temboard-agent",
         # development
         "agent/share/",
     ]

--- a/tests/fixtures/ui.py
+++ b/tests/fixtures/ui.py
@@ -425,8 +425,6 @@ def ui_sharedir():
     candidates = [
         # rpm/deb
         "/usr/share/temboard",
-        # pip install
-        "/usr/local/share/temboard",
         # development
         "ui/share/",
     ]

--- a/ui/README.md
+++ b/ui/README.md
@@ -7,12 +7,6 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.python.org/pypi/temboard" target="_blank">
-    <img src="https://img.shields.io/pypi/v/temboard.svg" alt="PyPI version" />
-  </a>
-  <a href="https://www.python.org/" target="_blank">
-    <img src="https://img.shields.io/pypi/pyversions/temboard.svg" alt="Supported Python versions" />
-  </a>
   <a href="https://circleci.com/gh/dalibo/temboard" target="_blank">
     <img src="https://circleci.com/gh/dalibo/temboard.svg?style=shield" alt="CI status" />
   </a>

--- a/ui/packaging/nfpm/mkdeb.sh
+++ b/ui/packaging/nfpm/mkdeb.sh
@@ -37,13 +37,8 @@ RELEASE=0dlb1${codename}1
 
 #       I N S T A L L
 
-whl="dist/temboard-$pep440v-py3-none-any.whl"
-if ! [ -f "$whl" ] ; then
-	pip3 download --only-binary :all: --no-deps --pre --dest "dist/" "temboard==$pep440v"
-fi
-
 # Install from sources
-pip3 install --pre --root "$DESTDIR" --prefix /usr --no-deps "$whl"
+pip3 install --pre --root "$DESTDIR" --prefix /usr --no-deps "dist/temboard-$pep440v-py3-none-any.whl"
 
 # Fake --install-layout=deb, when using wheel.
 pythonv=$(python3 --version |& grep -Po 'Python \K(3\.[0-9]{1,2})')

--- a/ui/packaging/nfpm/mkrpm.sh
+++ b/ui/packaging/nfpm/mkrpm.sh
@@ -37,13 +37,8 @@ RELEASE="1$(rpm --eval '%{dist}')"
 
 #       I N S T A L L
 
-whl="dist/temboard-$VERSION-py3-none-any.whl"
-if ! [ -f "$whl" ] ; then
-	"${pip[@]}" download --only-binary :all: --no-deps --pre --dest "dist/" "temboard==$VERSION"
-fi
-
 # Install from sources
-"${pip[@]}" install --pre --root "$DESTDIR" --prefix /usr --no-deps "$whl"
+"${pip[@]}" install --pre --root "$DESTDIR" --prefix /usr --no-deps "dist/temboard-$VERSION-py3-none-any.whl"
 # Vendor dependencies.
 pythonv=$("$python" --version |& grep -Po 'Python \K(3\.[0-9]{1,2})')
 uv pip install \

--- a/ui/pyproject.toml
+++ b/ui/pyproject.toml
@@ -8,13 +8,7 @@ license = "PostgreSQL"
 authors = [
     {name = "Dalibo", email = "contact@dalibo.com"},
 ]
-classifiers = [
-    "Intended Audience :: System Administrators",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3",
-    "Topic :: Database :: Database Engines/Servers",
-    "Topic :: System :: Monitoring",
-]
+classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "cryptography",
     # There is no hard dependency on psycopg2 to allow using


### PR DESCRIPTION
Since vendoring and move to pyproject.toml, bare pip install is totally broken and requires substantial manuals steps to properly setup UI and agent. This is not our wanted UX.